### PR TITLE
ギフトの日付を「日付未定」に変更したのに反映されない不具合を修正 #6

### DIFF
--- a/Memoria-iOS/Gift/GiftDataModel.swift
+++ b/Memoria-iOS/Gift/GiftDataModel.swift
@@ -29,11 +29,11 @@ struct GiftDataModel {
         dictionary["isReceived"] = isReceived
         dictionary["personName"] = personName
         dictionary["anniversaryName"] = anniversaryName
-        dictionary["date"] = date
+        dictionary["date"] = date ?? NSNull()
         dictionary["goods"] = goods
         dictionary["memo"] = memo
         dictionary["isHidden"] = isHidden
-        dictionary["iconImage"] = iconImage
+        dictionary["iconImage"] = iconImage ?? NSNull()
         
         return dictionary
     }


### PR DESCRIPTION
### Issueリンク
#6 

### 概要
一度、日付を選択して登録したギフトを編集画面で編集するときに、
「日付未定」に変更して再登録したにも関わらず反映されずに以前登録した日付が表示されてしまう不具合を修正しました。

### 実装の詳細
Firestore(DB)では、nilを登録しようとしても空になるわけではなく、「登録しない」という意味になる。
意図的に「空」の状態を登録したい場合は「NULL」を登録する必要がある。
登録時にnilをNSNULL()に変換することで対応しました。

### 影響範囲
ギフトの登録、編集時に影響があります。

### テストしたこと
iPhoneシミュレータにて、
1. ギフトの編集で、日付ありから日付未定として変更登録して反映されること
2. ギフトの編集で、日付未定から日付ありに変更登録して反映されること
3. ギフトを日付ありで新規登録できること
4. ギフトを日付未定で新規登録できること
以上の動作を確認しました。

@ikki-dev さんを初めてレビュアーに追加してみました！