### PR TITLE
記念日検索条件に「カテゴリー＝記念日」を追加して誕生日を除外 fixed #17

### DIFF
--- a/Memoria-iOS/Anniversary/AnniversaryData/AnniversaryDAO.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryData/AnniversaryDAO.swift
@@ -94,7 +94,7 @@ class AnniversaryDAO {
     ///   - whereField: 検索対象
     ///   - equalTo: 検索条件
     ///   - callback: ドキュメントのデータを受け取る
-    static func getFilteredAnniversaryDocuments(whereField: String,
+    static func getFilteredDocuments(whereField: String,
                              equalTo: Any,
                              callback: @escaping ([QueryDocumentSnapshot]) -> Void) {
         getQuery(whereField: whereField, equalTo: equalTo)?.getDocuments { (querySnapshot, error) in
@@ -110,6 +110,21 @@ class AnniversaryDAO {
         }
     }
 
+    static func getDocumentsAtDualFilter(first whereField: String, equalTo: Any,
+                             secondWhereField: String, secondEqualTo: Any,
+                             callback: @escaping ([QueryDocumentSnapshot]) -> Void) {
+        getQuery(whereField: whereField, equalTo: equalTo)?.whereField(secondWhereField, isEqualTo: secondEqualTo).getDocuments { (querySnapshot, error) in
+            if let error = error {
+                print("エラー発生: \(error)")
+            } else {
+                print("\(#function)の実行に成功")
+            }
+            // ドキュメントのアンラップと存在チェック
+            if let documents = querySnapshot?.documents {
+                callback(documents)
+            }
+        }
+    }
 
     // MARK: - データ登録・更新
     

--- a/Memoria-iOS/Gift/GiftRecord/GiftRecordSelectAnniversaryVC.swift
+++ b/Memoria-iOS/Gift/GiftRecord/GiftRecordSelectAnniversaryVC.swift
@@ -21,7 +21,7 @@ class GiftRecordSelectAnniversaryVC: UIViewController {
     var displayData = [String]()
     
     @IBOutlet weak var tableView: UITableView!
-    // TextFieldの文字列を書き換えるらためのDelegateを宣言
+    // TextFieldの文字列を書き換えるためのDelegateを宣言
     weak var delegate: GiftRecordSelectAnniversaryVCDelegate?
 
     override func viewDidLoad() {
@@ -35,10 +35,12 @@ class GiftRecordSelectAnniversaryVC: UIViewController {
 extension GiftRecordSelectAnniversaryVC: GiftRecordSelectProtocol {
     
     func searchDB() {
-        AnniversaryDAO.getFilteredAnniversaryDocuments(whereField: "isHidden", equalTo: false) { (queryDoc) in
+        // 非表示ではない記念日を検索する
+        AnniversaryDAO.getDocumentsAtDualFilter(first: "isHidden", equalTo: false, secondWhereField: "category", secondEqualTo: "anniversary") { (queryDoc) in
             for doc in queryDoc {
-                guard let title = doc.data()["title"] as? String else{ continue }
-                self.displayData.append(title)
+                if let title = doc.data()["title"] as? String {
+                    self.displayData.append(title)
+                }
             }
             self.tableView.reloadData()
         }

--- a/Memoria-iOS/Gift/GiftRecord/GiftRecordSelectPersonVC.swift
+++ b/Memoria-iOS/Gift/GiftRecord/GiftRecordSelectPersonVC.swift
@@ -35,7 +35,7 @@ class GiftRecordSelectPersonVC: UIViewController {
 extension GiftRecordSelectPersonVC: GiftRecordSelectProtocol {
     
     func searchDB() {
-        AnniversaryDAO.getFilteredAnniversaryDocuments(whereField: "isHidden", equalTo: false) { (queryDoc) in
+        AnniversaryDAO.getFilteredDocuments(whereField: "isHidden", equalTo: false) { (queryDoc) in
             for doc in queryDoc {
                 if doc.data()["familyName"] == nil, doc.data()["givenName"] == nil { continue }
                 var fullName = [String]()

--- a/Memoria-iOS/Util/Migration.swift
+++ b/Memoria-iOS/Util/Migration.swift
@@ -51,7 +51,7 @@ struct Migration {
                         DialogBox.updateAlert(with: "nextMigration".localized, on: rootVC) {
                             // ☆ 二つに分けた誕生日を一つにまとめる
                             // ① 非表示ではない記念日を検索
-                            AnniversaryDAO.getFilteredAnniversaryDocuments(whereField: "isHidden", equalTo: false) { (query) in
+                            AnniversaryDAO.getFilteredDocuments(whereField: "isHidden", equalTo: false) { (query) in
                                 print("Ver.2.1.0 の誕生日タイプマイグレーションを開始")
                                 guard query.count > 0 else {
                                     print("queryが空っぽです")


### PR DESCRIPTION
### 課題(Issue)リンク(例: #23)
#17 

### 概要
ギフト登録画面の記念日選択画面で、空行が表示されてしまう不具合を修正しました。
検索条件に「カテゴリー」の指定が足りていなかったため、追加して検索対象から誕生日を除外して解決

### 実装の詳細
DBアクセス用の構造体に、新たに「二つの条件で検索するメソッド」を追加して使用しました。
・記念日と誕生日の中から、記念日だけを指定する条件
・非表示になっている記念日は除く条件

### 影響範囲
ギフト登録時の記念日名選択画面に影響があります。

### テストしたこと
iPhoneシミュレータ (iOS 12.1)にて、
1. 空行が表示されないこと
2. 表示されている記念日を選択して、それが記念日登録画面で反映されていること 

以上の動作を確認しました。

### レビューポイント
本当は、2個の検索条件に対応するメソッドではなくて、
検索条件が可変個数でも対応できるメソッドを作りたかったんですが、思いつきませんでした…