### PR TITLE
fixed #4 記念日の編集を決定し,戻った画面で、編集内容が反映されていない

### DIFF
--- a/Memoria-iOS.xcodeproj/project.pbxproj
+++ b/Memoria-iOS.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		8D1C73C62183EE0D00DA5A14 /* Anniversary.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D1C73C52183EE0D00DA5A14 /* Anniversary.storyboard */; };
 		8D2507B621A44E860015A206 /* AccentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D2507B521A44E850015A206 /* AccentButton.swift */; };
 		8D3E561521BAAA840090E46E /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3E561421BAAA840090E46E /* AppInfo.swift */; };
+		8D42F605222AC4BE00F01A77 /* AnniversaryUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D42F604222AC4BE00F01A77 /* AnniversaryUtil.swift */; };
 		8D4CBB1821C0001D009BA7C6 /* Gift.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D4CBB1721C0001D009BA7C6 /* Gift.storyboard */; };
 		8D4CBB1A21C002C3009BA7C6 /* GiftVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4CBB1921C002C3009BA7C6 /* GiftVC.swift */; };
 		8D4CBB1C21C1511F009BA7C6 /* GiftDAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4CBB1B21C1511F009BA7C6 /* GiftDAO.swift */; };
@@ -125,6 +126,7 @@
 		8D1C73C52183EE0D00DA5A14 /* Anniversary.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Anniversary.storyboard; path = "Memoria-iOS/Anniversary/Anniversary.storyboard"; sourceTree = SOURCE_ROOT; };
 		8D2507B521A44E850015A206 /* AccentButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentButton.swift; sourceTree = "<group>"; };
 		8D3E561421BAAA840090E46E /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
+		8D42F604222AC4BE00F01A77 /* AnniversaryUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryUtil.swift; sourceTree = "<group>"; };
 		8D4CBB1721C0001D009BA7C6 /* Gift.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Gift.storyboard; sourceTree = "<group>"; };
 		8D4CBB1921C002C3009BA7C6 /* GiftVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftVC.swift; sourceTree = "<group>"; };
 		8D4CBB1B21C1511F009BA7C6 /* GiftDAO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftDAO.swift; sourceTree = "<group>"; };
@@ -316,6 +318,7 @@
 				8D910B5021E20CC300D072EA /* AnniversaryDetail */,
 				8D0BE31D21A0404900FE9B40 /* AnniversaryRecord */,
 				8D910B4B21E19F1000D072EA /* AnniversaryEdit */,
+				8D42F604222AC4BE00F01A77 /* AnniversaryUtil.swift */,
 			);
 			path = Anniversary;
 			sourceTree = "<group>";
@@ -641,6 +644,7 @@
 				8DC43FE421D9F53600B911F2 /* GiftDataModel.swift in Sources */,
 				8D2507B621A44E860015A206 /* AccentButton.swift in Sources */,
 				8DB8105321A915B20007BBC5 /* HiddenListVC.swift in Sources */,
+				8D42F605222AC4BE00F01A77 /* AnniversaryUtil.swift in Sources */,
 				8DAE856321A2F1B90049063D /* InspectableLabel.swift in Sources */,
 				8DC43FDE21D3C78F00B911F2 /* GiftRecordSelectAnniversaryVC.swift in Sources */,
 				8DD486F421EAD68D0072983A /* Migration.swift in Sources */,

--- a/Memoria-iOS/Anniversary/AnniversaryDetail/AnniversaryDetailVC.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryDetail/AnniversaryDetailVC.swift
@@ -201,9 +201,7 @@ extension AnniversaryDetailVC: UITableViewDataSource, UITableViewDelegate {
             cell = tableView.dequeueReusableCell(withIdentifier: "topCell", for: indexPath)
             // 記念日のアイコン
             let imageView = cell.viewWithTag(1) as! UIImageView
-            if let iconImage = anniversary["iconImage"] as? Data {
-                imageView.image = UIImage(data: iconImage)
-            }
+            imageView.image = AnniversaryUtil.getIconImage(from: anniversary)
             // 記念日の名前
             let anniversaryNameLabel = cell.viewWithTag(2) as! UILabel
             anniversaryNameLabel.text = AnniversaryUtil.getName(from: anniversary)

--- a/Memoria-iOS/Anniversary/AnniversaryUtil.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryUtil.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 nerco studio. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 struct AnniversaryUtil {
     /// 記念日か誕生日かによってタイトルが違うので、ここで判断して返す
@@ -28,8 +28,32 @@ struct AnniversaryUtil {
         }
     }
     
+    /// 次の記念日までの日数を文字列で取得する
+    ///
+    /// - Parameter remainingDays: 次回記念日までの日数
+    /// - Returns: 後何日か、もしくは何日過ぎたかを文字列で返す
     static func getRemainingDaysString(from remainingDays: Int) -> String {
         return remainingDays >= 0
             ? String(format: "remainingDays".localized, remainingDays.description)
-            : String(format: "elapsedDays".localized, (-remainingDays).description)    }
+            : String(format: "elapsedDays".localized, (-remainingDays).description)
+        
+    }
+    
+    /// 記念日のアイコン画像を返す、ない場合はデフォルト画像を返す
+    ///
+    /// - Parameter anniversary: 記念日データ
+    /// - Returns: 登録済みデータで作ったアイコン画像か、デフォルト画像を返す
+    static func getIconImage(from anniversary: [String : Any]) -> UIImage {
+        if let iconImageData = anniversary["iconImage"] as? Data,
+            let iconImage = UIImage(data: iconImageData) {
+            return iconImage
+        } else {
+            // 記念日の分類
+            let category = AnniversaryType(category: anniversary["category"] as! String)
+            // アイコンがない場合はデフォルトアイコンを使用
+            return category == .birthday
+                ? #imageLiteral(resourceName: "Ribbon") // 誕生日
+                : #imageLiteral(resourceName: "PresentBox") // それ以外
+        }
+    }
 }

--- a/Memoria-iOS/Anniversary/AnniversaryUtil.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryUtil.swift
@@ -1,0 +1,35 @@
+//
+//  AnniversaryUtil.swift
+//  Memoria-iOS
+//
+//  Created by 村松龍之介 on 2019/03/02.
+//  Copyright © 2019 nerco studio. All rights reserved.
+//
+
+import Foundation
+
+struct AnniversaryUtil {
+    /// 記念日か誕生日かによってタイトルが違うので、ここで判断して返す
+    ///
+    /// - Parameter anniversary: 記念日データ
+    /// - Returns: 記念日名か、人名を文字列で返却
+    static func getName(from anniversary: [String : Any]) -> String? {
+        // 記念日の分類
+        let category = AnniversaryType(category: anniversary["category"] as! String)
+        // 記念日の名称。誕生日だったら苗字と名前を繋げて表示
+        switch category {
+        case .anniversary:
+            return anniversary["title"] as? String
+            
+        case .birthday:
+            return String(format: "whoseBirthday".localized,
+                          arguments: [anniversary["familyName"] as! String,
+                                      anniversary["givenName"] as! String])
+        }
+    }
+    
+    static func getRemainingDaysString(from remainingDays: Int) -> String {
+        return remainingDays >= 0
+            ? String(format: "remainingDays".localized, remainingDays.description)
+            : String(format: "elapsedDays".localized, (-remainingDays).description)    }
+}

--- a/Memoria-iOS/Anniversary/AnniversaryVC.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryVC.swift
@@ -225,23 +225,11 @@ final class AnniversaryVC: UICollectionViewController {
         }
         // 記念日の名前
         cell.anniversaryNameLabel.text = AnniversaryUtil.getName(from: anniversary)
-        
         // 記念日の日程
         guard let anniversaryDate = (anniversary["date"] as? Timestamp)?.dateValue() else { return cell }
         cell.anniversaryDateLabel.text = DateTimeFormat.getMonthDayString(date: anniversaryDate)
-        
         // 記念日のアイコン
-        if let iconImage = anniversary["iconImage"] as? Data {
-            cell.anniversaryIconImage.image = UIImage(data: iconImage)
-        } else {
-            // 記念日の分類
-            let category = AnniversaryType(category: anniversary["category"] as! String)
-            // アイコンがない場合はデフォルトアイコンを使用
-            cell.anniversaryIconImage.image = category == .birthday
-                ? #imageLiteral(resourceName: "Ribbon") // 誕生日
-                : #imageLiteral(resourceName: "PresentBox") // それ以外
-        }
-        
+        cell.anniversaryIconImage.image = AnniversaryUtil.getIconImage(from: anniversary)
         // 記念日までの残り日数
         let remainingDays = anniversary["remainingDays"] as! Int
         cell.remainingDaysLabel.text = AnniversaryUtil.getRemainingDaysString(from: remainingDays)

--- a/Memoria-iOS/Anniversary/AnniversaryVC.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryVC.swift
@@ -21,7 +21,6 @@ final class AnniversaryVC: UICollectionViewController {
     
     /// 正直まだよく理解していないリスナー登録？
     var listenerRegistration: ListenerRegistration?
-    var authStateListenerHandler: AuthStateDidChangeListenerHandle?
     
     /// 記念日データ配列
     var anniversarys = [[String: Any]]()
@@ -90,7 +89,6 @@ final class AnniversaryVC: UICollectionViewController {
         if id == "toDetailSegue" {
             let nextVC = segue.destination as! AnniversaryDetailVC
             guard let indexPath = collectionView.indexPathsForSelectedItems?.first else { return }
-            let cell = collectionView.cellForItem(at: indexPath) as! AnniversaryCell
             switch indexPath.section {
             case 0:
                 nextVC.anniversary = anniversarys[indexPath.row]
@@ -98,9 +96,6 @@ final class AnniversaryVC: UICollectionViewController {
                 nextVC.anniversary = alreadyFinishedAnniversary[indexPath.row]
             default : fatalError()
             }
-            nextVC.anniversaryName = cell.anniversaryNameLabel.text
-            nextVC.remainingDays = cell.remainingDaysLabel.text
-            nextVC.iconImage = cell.anniversaryIconImage.image
         }
     }
     
@@ -228,18 +223,8 @@ final class AnniversaryVC: UICollectionViewController {
         case 1: anniversary = self.alreadyFinishedAnniversary[indexPath.row]
         default: fatalError()
         }
-        // 記念日の分類
-        let category = AnniversaryType(category: anniversary["category"] as! String)
-        
-        // 記念日の名称。誕生日だったら苗字と名前を繋げて表示
-        switch category {
-        case .anniversary:
-            cell.anniversaryNameLabel.text = anniversary["title"] as? String
-
-        case .birthday:
-            cell.anniversaryNameLabel.text = String(format: "whoseBirthday".localized,
-                                                    arguments: [anniversary["familyName"] as! String, anniversary["givenName"] as! String])
-        }
+        // 記念日の名前
+        cell.anniversaryNameLabel.text = AnniversaryUtil.getName(from: anniversary)
         
         // 記念日の日程
         guard let anniversaryDate = (anniversary["date"] as? Timestamp)?.dateValue() else { return cell }
@@ -249,6 +234,8 @@ final class AnniversaryVC: UICollectionViewController {
         if let iconImage = anniversary["iconImage"] as? Data {
             cell.anniversaryIconImage.image = UIImage(data: iconImage)
         } else {
+            // 記念日の分類
+            let category = AnniversaryType(category: anniversary["category"] as! String)
             // アイコンがない場合はデフォルトアイコンを使用
             cell.anniversaryIconImage.image = category == .birthday
                 ? #imageLiteral(resourceName: "Ribbon") // 誕生日
@@ -257,9 +244,7 @@ final class AnniversaryVC: UICollectionViewController {
         
         // 記念日までの残り日数
         let remainingDays = anniversary["remainingDays"] as! Int
-        cell.remainingDaysLabel.text = remainingDays >= 0
-            ? String(format: "remainingDays".localized, remainingDays.description)
-            : String(format: "elapsedDays".localized, (-remainingDays).description)
+        cell.remainingDaysLabel.text = AnniversaryUtil.getRemainingDaysString(from: remainingDays)
         
         // 残り日数によってセルの見た目を変化させる
         var layer: CAGradientLayer?


### PR DESCRIPTION
### 課題(Issue)リンク(例: #23)
#4 

### 概要
記念日の編集を決定し、戻った記念日詳細画面で、編集内容が反映されていない
を修正しました。

### 実装の詳細
Firestoreの機能である、リスナー登録で、記念日に変更があった場合自動で表示データを更新するよう変更しました。

アイコン画像のセットをUtilクラスにまとめたり…
色々とリファクタリングしていたら、変更範囲が広くなってしまいました。

### 影響範囲
記念日の詳細画面を表示した時、編集画面から詳細画面に戻ってきた時に影響があります。

### テストしたこと
iPhone X (iOS 12.1.4)にて、
1. 記念日詳細画面を開いた時に正しく情報が表示されていること
2. 編集ボタンを押して、記念日を編集して戻ってきた時に記念日情報が更新されていること
3. アイコン画像が登録されていないものでもデフォルト画像が表示されること

以上の動作を確認しました。