### PR TITLE
日付をピッカーで変更してもラベルに反映されない不具合とValidate動作を修正

### DIFF
--- a/Memoria-iOS/Anniversary/AnniversaryEdit/AnniversaryEdit.storyboard
+++ b/Memoria-iOS/Anniversary/AnniversaryEdit/AnniversaryEdit.storyboard
@@ -29,7 +29,7 @@
                                 </connections>
                             </containerView>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="SpR-bI-R5I" customClass="InspectableSegmentedControl" customModule="Memoria_iOS" customModuleProvider="target">
-                                <rect key="frame" x="103" y="82" width="169" height="29"/>
+                                <rect key="frame" x="112.5" y="82" width="150" height="29"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="jeo-Ix-jwd"/>
                                 </constraints>
@@ -66,7 +66,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="1kt-Gh-au1" customClass="InspectableStackView" customModule="Memoria_iOS" customModuleProvider="target">
                                 <rect key="frame" x="16" y="158.5" width="343" height="44.5"/>
                                 <subviews>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Y6a-G3-5nv" customClass="InspectableTextField" customModule="Memoria_iOS" customModuleProvider="target">
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="unlessEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Y6a-G3-5nv" customClass="InspectableTextField" customModule="Memoria_iOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="106.5" height="44.5"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -79,7 +79,7 @@
                                             <outlet property="delegate" destination="CDS-0C-eHY" id="weO-Ms-2bv"/>
                                         </connections>
                                     </textField>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="osb-jM-eE3" customClass="InspectableTextField" customModule="Memoria_iOS" customModuleProvider="target">
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="unlessEditing" translatesAutoresizingMaskIntoConstraints="NO" id="osb-jM-eE3" customClass="InspectableTextField" customModule="Memoria_iOS" customModuleProvider="target">
                                         <rect key="frame" x="118.5" y="0.0" width="106" height="44.5"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -88,11 +88,11 @@
                                             <userDefinedRuntimeAttribute type="string" keyPath="placeholderLocalizedStringKey" value="leftNamePlaceholder"/>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <action selector="textFieldEditingChanged:" destination="CDS-0C-eHY" eventType="editingDidEnd" id="b3C-bb-gt9"/>
+                                            <action selector="textFieldEditingChanged:" destination="CDS-0C-eHY" eventType="editingChanged" id="uAT-sn-rxp"/>
                                             <outlet property="delegate" destination="CDS-0C-eHY" id="A1e-Lb-ISC"/>
                                         </connections>
                                     </textField>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kR2-0O-kI4" customClass="InspectableTextField" customModule="Memoria_iOS" customModuleProvider="target">
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="unlessEditing" translatesAutoresizingMaskIntoConstraints="NO" id="kR2-0O-kI4" customClass="InspectableTextField" customModule="Memoria_iOS" customModuleProvider="target">
                                         <rect key="frame" x="236.5" y="0.0" width="106.5" height="44.5"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -101,7 +101,7 @@
                                             <userDefinedRuntimeAttribute type="string" keyPath="placeholderLocalizedStringKey" value="rightNamePlaceholder"/>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <action selector="textFieldEditingChanged:" destination="CDS-0C-eHY" eventType="editingDidEnd" id="woI-qX-w8L"/>
+                                            <action selector="textFieldEditingChanged:" destination="CDS-0C-eHY" eventType="editingChanged" id="xfx-h3-CEv"/>
                                             <outlet property="delegate" destination="CDS-0C-eHY" id="fdc-px-hYe"/>
                                         </connections>
                                     </textField>
@@ -220,7 +220,6 @@
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" returnKeyType="next"/>
                                                     <connections>
-                                                        <action selector="textFieldEditingChanged:" destination="TZb-Mu-70l" eventType="editingDidEnd" id="ylS-E1-F7g"/>
                                                         <outlet property="delegate" destination="TZb-Mu-70l" id="mEA-GI-v01"/>
                                                     </connections>
                                                 </textField>

--- a/Memoria-iOS/Anniversary/AnniversaryEdit/AnniversaryEditTableVC.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryEdit/AnniversaryEditTableVC.swift
@@ -66,6 +66,7 @@ class AnniversaryEditTableVC: UITableViewController {
         dateField.text = DateTimeFormat.getYMDString(date: datePicker.date)
         // 登録時の日付参照用変数に日付情報を代入
         timestamp = Timestamp(date: datePicker.date)
+        anniversaryEditTableVCDelegate?.needValidation(with: true)
     }
     
     

--- a/Memoria-iOS/Anniversary/AnniversaryEdit/AnniversaryEditVC.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryEdit/AnniversaryEditVC.swift
@@ -115,24 +115,7 @@ class AnniversaryEditVC: UIViewController {
     }
     
     @IBAction func textFieldEditingChanged(_ sender: InspectableTextField) {
-        switch AnniversaryType(rawValue: anniversaryTypeChoice.selectedSegmentIndex)! {
-        case .anniversary:
-            if !(anniversaryTitleField.text?.isEmpty ?? true) {
-                recordButton.isEnabled = true
-            } else {
-                recordButton.isEnabled = false
-            }
-            
-        case .birthday:
-            if !(leftNameField.text?.isEmpty ?? true),
-                !(rightNameField.text?.isEmpty ?? true) {
-                recordButton.isEnabled = true
-                print("enabled")
-            } else {
-                recordButton.isEnabled = false
-                print("desabled")
-            }
-        }
+        validate()
     }
     
     
@@ -212,6 +195,17 @@ class AnniversaryEditVC: UIViewController {
             hideAnniversaryButton.isHidden = true
         }
     }
+    
+    private func validate() {
+        switch AnniversaryType(rawValue: anniversaryTypeChoice.selectedSegmentIndex)! {
+        case .anniversary: // 記念日名が入力されていればOK
+            recordButton.isEnabled = !(anniversaryTitleField.text?.isEmpty ?? true)
+            
+        case .birthday: // 姓名が入力されていればOK
+            recordButton.isEnabled = !(leftNameField.text?.isEmpty ?? true)
+                && !(rightNameField.text?.isEmpty ?? true)
+        }
+    }
 }
 
 
@@ -220,6 +214,7 @@ extension AnniversaryEditVC: UITextFieldDelegate {
     
     /// Did tap CLEAR button
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        // 記念日の名前か姓名TextFieldのクリアボタンが押されたら登録ボタンを無効化する（ここには日付含まず）
         recordButton.isEnabled = false
         return true
     }
@@ -257,37 +252,19 @@ extension AnniversaryEditVC: UITextViewDelegate{
         }
         return true
     }
-    
+    /// メモが書き換えられたら
     func textViewDidChange(_ textView: UITextView) {
         memoView.togglePlaceholder()
-        
-        // TODO: 重複内容だから共通化するAnniversaryType生成するのは一回のみにする
-        switch AnniversaryType(rawValue: anniversaryTypeChoice.selectedSegmentIndex)! {
-        case .anniversary:
-            if !(anniversaryTitleField.text?.isEmpty ?? true) {
-                recordButton.isEnabled = true
-            } else {
-                recordButton.isEnabled = false
-            }
-            
-        case .birthday:
-            if !(leftNameField.text?.isEmpty ?? true),
-                !(rightNameField.text?.isEmpty ?? true) {
-                recordButton.isEnabled = true
-                print("enabled")
-            } else {
-                recordButton.isEnabled = false
-                print("desabled")
-            }
-        }
+        validate()
     }
 }
 
 
 // MARK: - AnniversaryEditTableVC Delegate
-// 登録ボタンの有効・無効を切り替えるデリゲート
+// TableVCから通知を受けて、登録ボタンの有効・非有効化を検証するメソッドを呼ぶ
 extension AnniversaryEditVC: AnniversaryEditTableVCDelegate {
-    func recordingStandby(_ enabled: Bool) {
-        recordButton.isEnabled = enabled
+    func needValidation(with enabled: Bool) {
+        // v2.0.1現在、必ずtrueで呼ばれる
+        if enabled { validate() }
     }
 }

--- a/Memoria-iOS/Gift/GiftRecord/GiftRecord.storyboard
+++ b/Memoria-iOS/Gift/GiftRecord/GiftRecord.storyboard
@@ -190,7 +190,7 @@
                                                         <userDefinedRuntimeAttribute type="string" keyPath="placeholderLocalizedStringKey" value="placeholderAnniversary"/>
                                                     </userDefinedRuntimeAttributes>
                                                     <connections>
-                                                        <action selector="textFieldEditingChanged:" destination="ZrE-8n-IyQ" eventType="editingDidEnd" id="bPP-qY-gdJ"/>
+                                                        <action selector="textFieldEditingChanged:" destination="ZrE-8n-IyQ" eventType="editingChanged" id="QzL-Kf-DcR"/>
                                                         <outlet property="delegate" destination="ZrE-8n-IyQ" id="lzN-3Z-xem"/>
                                                     </connections>
                                                 </textField>
@@ -242,7 +242,7 @@
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" returnKeyType="next"/>
                                                     <connections>
-                                                        <action selector="textFieldEditingChanged:" destination="ZrE-8n-IyQ" eventType="editingDidEnd" id="pHd-qR-GPX"/>
+                                                        <action selector="textFieldEditingChanged:" destination="ZrE-8n-IyQ" eventType="editingChanged" id="Kyn-6r-Jwe"/>
                                                         <outlet property="delegate" destination="ZrE-8n-IyQ" id="fd2-vA-lfU"/>
                                                     </connections>
                                                 </textField>
@@ -283,7 +283,7 @@
                                                         <userDefinedRuntimeAttribute type="string" keyPath="placeholderLocalizedStringKey" value="placeholderGoods"/>
                                                     </userDefinedRuntimeAttributes>
                                                     <connections>
-                                                        <action selector="textFieldEditingChanged:" destination="ZrE-8n-IyQ" eventType="editingDidEnd" id="CW8-1C-JXf"/>
+                                                        <action selector="textFieldEditingChanged:" destination="ZrE-8n-IyQ" eventType="editingChanged" id="3lK-f5-VeZ"/>
                                                         <outlet property="delegate" destination="ZrE-8n-IyQ" id="jpG-7x-G2o"/>
                                                     </connections>
                                                 </textField>

--- a/Memoria-iOS/Gift/GiftRecord/GiftRecordTableVC.swift
+++ b/Memoria-iOS/Gift/GiftRecord/GiftRecordTableVC.swift
@@ -88,19 +88,13 @@ class GiftRecordTableVC: UITableViewController {
     // MARK: - IBAction method
     
     @IBAction func textFieldEditingChanged(_ sender: UITextField) {
-        print(#function)
-        checkReadyForRecording()
-        
-        if sender == dateField {
-            dateField.text = DateTimeFormat.getYMDString(date: datePicker.date)
-            timestamp = Timestamp(date: datePicker.date)
-        }
+        validate()
     }
     
     @IBAction private func toggleDateTBD(_ sender: UISwitch) {
         print(#function)
         doDateTBD(isTBD: sender.isOn)
-        checkReadyForRecording()
+        validate()
     }
     
     func doDateTBD(isTBD: Bool) {
@@ -116,7 +110,7 @@ class GiftRecordTableVC: UITableViewController {
     
     // MARK: - Private Method
     
-    private func checkReadyForRecording() {
+    private func validate() {
         if !(personNameField.text?.isEmpty ?? true),
             !(anniversaryNameField.text?.isEmpty ?? true),
             !(goodsField.text?.isEmpty ?? true) {
@@ -138,12 +132,21 @@ class GiftRecordTableVC: UITableViewController {
     private func setupDatePicker() {
         datePicker = UIDatePicker()
         datePicker.datePickerMode = .date
+        datePicker.addTarget(self, action: #selector(didChangedDatePickerDate), for: .valueChanged)
         // placeholder is today
         dateField.placeholder = DateTimeFormat.getYMDString()
         dateField.inputAccessoryView = setupKeyboardToolbar()
         dateField.inputView = datePicker
     }
     
+    @objc private func didChangedDatePickerDate() {
+        // 日付ラベルにピッカーの日付を反映する
+        dateField.text = DateTimeFormat.getYMDString(date: datePicker.date)
+        // 登録時の日付参照用変数に日付情報を代入
+        timestamp = Timestamp(date: datePicker.date)
+        validate()
+    }
+
     private func setupKeyboardToolbar() -> UIToolbar {
         let toolbar = UIToolbar()
         toolbar.frame = CGRect(x: 0, y: 0, width: self.view.frame.width, height: 44)
@@ -230,9 +233,14 @@ class GiftRecordTableVC: UITableViewController {
 // MARK: - Text field delegate
 extension GiftRecordTableVC: UITextFieldDelegate {
     
-    /// Did tap CLEAR button
+    /// クリアボタンを押した時
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
-        giftRecordTableVCDelegate?.recordingStandby(false)
+        if textField == dateField {
+            let today = Date()
+            datePicker.date = today
+            timestamp = Timestamp(date: today)
+        }
+        validate()
         return true
     }
     
@@ -250,20 +258,18 @@ extension GiftRecordTableVC: UITextFieldDelegate {
 
 // MARK: - GiftRecordSelectPersonVC Delegate
 extension GiftRecordTableVC: GiftRecordSelectPersonVCDelegate {
-    
-    /// Update Person name
+    /// 選択用画面経由で人名を更新した時
     func updatePersonName(with text: String?) {
-        print(#function, text ?? "nil")
         personNameField.text = text
+        validate()
     }
 }
 
 // MARK: - GiftRecordSelectAnniversaryVC Delegate
 extension GiftRecordTableVC: GiftRecordSelectAnniversaryVCDelegate {
-    
-    /// Update Anniversary name
+    /// 選択用画面経由で記念日名を更新した時
     func updateAnniversaryName(with text: String?) {
-        print(#function, text ?? "nil")
         anniversaryNameField.text = text
+        validate()
     }
 }


### PR DESCRIPTION
### 課題(Issue)リンク
#20 

### 概要

- 日付をピッカーで変更してもラベルに反映されない不具合
- 編集したのに登録ボタンを押せない不具合

を修正しました

### 実装の詳細

- ピッカーで日付を変更したら、即ラベルに反映＆Validateを走らせる
- クリアボタンを押してもValidateを走らせる
- Validateロジックの見直し

### 影響範囲
記念日・ギフトの登録・編集に影響

### テストしたこと
iPhone X (iOS 12)にて、
1. きちんとValidateされて適切なタイミングで登録ボタンの有効・非有効が切り替わること
2. 日付の変更がすぐにラベルに反映されること
3. 日付をクリアしたら、当日の日付になること

以上の動作を確認しました。