### PR TITLE
当日の表示を修正、過去の記念日だけを半透明化 Fixed #25

### DIFF
--- a/Memoria-iOS/Anniversary/AnniversaryCell.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryCell.swift
@@ -24,7 +24,7 @@ final class AnniversaryCell: UICollectionViewCell {
         anniversaryDateLabel.textColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
         backgroundColor = #colorLiteral(red: 0.8901960784, green: 0.8901960784, blue: 0.8901960784, alpha: 1)
         remainingDaysLabel.backgroundColor = #colorLiteral(red: 1, green: 0.6629999876, blue: 0.07800000161, alpha: 1)
-        
+        contentView.alpha = 1.0
         // 背景色として使っているグラデをリセットする
         guard let layer = layer.sublayers else { return }
         for layer in layer {

--- a/Memoria-iOS/Anniversary/AnniversaryVC.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryVC.swift
@@ -255,15 +255,20 @@ final class AnniversaryVC: UICollectionViewController {
                 : #imageLiteral(resourceName: "PresentBox") // それ以外
         }
         
-        // 記念日までの残り日数
+        // 記念日までの残り日数によって分岐させていく
         let remainingDays = anniversary["remainingDays"] as! Int
-        cell.remainingDaysLabel.text = remainingDays >= 0
-            ? String(format: "remainingDays".localized, remainingDays.description)
-            : String(format: "elapsedDays".localized, (-remainingDays).description)
-        
-        // 残り日数によってセルの見た目を変化させる
+        // 過去の記念日かどうか
+        let isPastAnniversary = remainingDays < 0
+        // 過去の記念日は薄くする
+        cell.contentView.alpha = isPastAnniversary ? 0.4 : 1.0
+        // 過去の記念日は「〜日前」と表示する
+        cell.remainingDaysLabel.text = isPastAnniversary
+            ? String(format: "elapsedDays".localized, (-remainingDays).description)
+            : String(format: "remainingDays".localized, remainingDays.description)
+        // グラデーションのためのレイヤー
         var layer: CAGradientLayer?
-        if 0 < remainingDays, remainingDays <= 30 {
+        // 近日中の記念日設定
+        if 0...30 ~= remainingDays {
             // 文字
             cell.anniversaryNameLabel.textColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
             cell.anniversaryDateLabel.textColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
@@ -274,34 +279,34 @@ final class AnniversaryVC: UICollectionViewController {
             layer?.endPoint = CGPoint(x: 0.5, y: 0)
             layer?.name = "grade"
         }
+        // 特別な残日数の設定
         switch remainingDays {
-        case -1:
+        case -1:  // 昨日
             cell.remainingDaysLabel.text = "remainingDaysYesterday".localized
-            fallthrough
-        case ...0:
-            cell.alpha = 0.7
             
-        case 0:
-            // 背景
-            let startColor = #colorLiteral(red: 0.8235294118, green: 0.0862745098, blue: 0.3921568627, alpha: 1).cgColor
-            let endColor = #colorLiteral(red: 0.5529411765, green: 0.2235294118, blue: 1, alpha: 1).cgColor
-            layer?.colors = [startColor, endColor]
-            cell.layer.insertSublayer(layer!, at: 0)
-            // 「当日」と表示する
+        case 0:  // 当日
+            if let layer = layer {
+                // 背景
+                let startColor = #colorLiteral(red: 0.8235294118, green: 0.0862745098, blue: 0.3921568627, alpha: 1).cgColor
+                let endColor = #colorLiteral(red: 0.5529411765, green: 0.2235294118, blue: 1, alpha: 1).cgColor
+                layer.colors = [startColor, endColor]
+                cell.layer.insertSublayer(layer, at: 0)
+            }
             cell.remainingDaysLabel.text = "remainingDaysToday".localized
 
-        case 1:
-            // 「明日」と表示する
+        case 1:  // 明日
             cell.remainingDaysLabel.text = "remainingDaysTomorrow".localized
             fallthrough
-        case ...30:
-            // 背景
-            cell.remainingDaysLabel.backgroundColor = #colorLiteral(red: 0.9254902005, green: 0.2352941185, blue: 0.1019607857, alpha: 1)
-            let startColor = #colorLiteral(red: 0.9764705896, green: 0.850980401, blue: 0.5490196347, alpha: 1).cgColor
-            let endColor = #colorLiteral(red: 1, green: 0.5781051517, blue: 0, alpha: 1).cgColor
-            layer?.colors = [startColor, endColor]
-            cell.layer.insertSublayer(layer!, at: 0)
             
+        case ...30:  // 30日以内
+            if let layer = layer {
+            // 背景
+                cell.remainingDaysLabel.backgroundColor = #colorLiteral(red: 0.9254902005, green: 0.2352941185, blue: 0.1019607857, alpha: 1)
+                let startColor = #colorLiteral(red: 0.9764705896, green: 0.850980401, blue: 0.5490196347, alpha: 1).cgColor
+                let endColor = #colorLiteral(red: 1, green: 0.5781051517, blue: 0, alpha: 1).cgColor
+                layer.colors = [startColor, endColor]
+                cell.layer.insertSublayer(layer, at: 0)
+            }
         default: break
         }
         return cell


### PR DESCRIPTION
### 課題(Issue)リンク
#25 

### 概要
当日なら「当日です！」と表示するように修正
過去の記念日に設定した透明度が、セルの再利用で他のセルに飛び火してしまっていたのも修正

### 実装の詳細
switchのcaseを整理してきちんと当日用のケースに飛ぶように修正
cell.alpha -> cell.contentView.alpha に修正

### 影響範囲
記念日一覧画面の表示

### テストしたこと
iPhone X (iOS )にて、
1. 過去の記念日のみが半透明になっていること
2. 画面をスクロールしたり、更新しても透明度や色が変わらないこと
3. 当日の記念日は「今日です！」と表示されること

以上の動作を確認しました。