### PR TITLE
2日後〜30日後の記念日の場合に日数が正しく表示されないバグを修正 fixed #36

### DIFF
--- a/Memoria-iOS/Anniversary/AnniversaryVC.swift
+++ b/Memoria-iOS/Anniversary/AnniversaryVC.swift
@@ -276,6 +276,7 @@ final class AnniversaryVC: UICollectionViewController {
                 layer.colors = [startColor, endColor]
                 cell.layer.insertSublayer(layer, at: 0)
             }
+            fallthrough // 残日数文字列をセットするためにdefaultへ
         default: // 2日以前、31日以降の記念日すべて
             // 記念日までの残り日数文字列
             cell.remainingDaysLabel.text = AnniversaryUtil.getRemainingDaysString(from: remainingDays)

--- a/Memoria-iOS/Info.plist
+++ b/Memoria-iOS/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>13</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSContactsUsageDescription</key>


### PR DESCRIPTION
### 課題(Issue)リンク
#36 

### 実装の詳細
日数によって処理を分岐させて日数ラベルに文字列をセットするswitch文で、件の日数だとラベルに文字列がセットできていなかった

### 影響範囲
記念日一覧を表示した時

### テストしたこと
iPhone (iOS )にて、
2日後と30日後の記念日が日数ラベルに異常がないこと

以上の動作を確認しました。