### PR TITLE
AnniversaryをAnnivに変更しました fixed #32

### DIFF
--- a/Memoria-iOS.xcodeproj/project.pbxproj
+++ b/Memoria-iOS.xcodeproj/project.pbxproj
@@ -17,21 +17,21 @@
 		8D0FB8492182002800BFCB79 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D0FB8472182002800BFCB79 /* LaunchScreen.storyboard */; };
 		8D0FB8512182013E00BFCB79 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8D0FB8502182013E00BFCB79 /* GoogleService-Info.plist */; };
 		8D0FB8542182068100BFCB79 /* ContactAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0FB8532182068100BFCB79 /* ContactAccess.swift */; };
-		8D0FB85621821B3B00BFCB79 /* AnniversaryDAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0FB85521821B3B00BFCB79 /* AnniversaryDAO.swift */; };
+		8D0FB85621821B3B00BFCB79 /* AnnivDAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0FB85521821B3B00BFCB79 /* AnnivDAO.swift */; };
 		8D11B3B12193B94200C60371 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 8D11B3B02193B94200C60371 /* README.md */; };
 		8D11B3B42193EE4F00C60371 /* IconImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D11B3B32193EE4F00C60371 /* IconImageView.swift */; };
 		8D11B3B721940BD100C60371 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8D11B3B921940BD100C60371 /* Localizable.strings */; };
-		8D11B3BC2194431100C60371 /* AnniversaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D11B3BB2194431100C60371 /* AnniversaryCell.swift */; };
+		8D11B3BC2194431100C60371 /* AnnivCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D11B3BB2194431100C60371 /* AnnivCell.swift */; };
 		8D11B3BF21947EAF00C60371 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8D11B3C121947EAF00C60371 /* InfoPlist.strings */; };
-		8D11B3C32195C5CD00C60371 /* AnniversaryDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D11B3C22195C5CC00C60371 /* AnniversaryDetail.storyboard */; };
-		8D11B3C52195CBF300C60371 /* AnniversaryDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D11B3C42195CBF300C60371 /* AnniversaryDetailVC.swift */; };
+		8D11B3C32195C5CD00C60371 /* AnnivDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D11B3C22195C5CC00C60371 /* AnnivDetail.storyboard */; };
+		8D11B3C52195CBF300C60371 /* AnnivDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D11B3C42195CBF300C60371 /* AnnivDetailVC.swift */; };
 		8D11B3C7219719B800C60371 /* TagLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D11B3C6219719B800C60371 /* TagLabel.swift */; };
 		8D1BFBB22185C6870082C766 /* DateTimeFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1BFBB12185C6870082C766 /* DateTimeFormat.swift */; };
-		8D1C73C32183ED6C00DA5A14 /* AnniversaryVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1C73C22183ED6C00DA5A14 /* AnniversaryVC.swift */; };
-		8D1C73C62183EE0D00DA5A14 /* Anniversary.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D1C73C52183EE0D00DA5A14 /* Anniversary.storyboard */; };
+		8D1C73C32183ED6C00DA5A14 /* AnnivVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1C73C22183ED6C00DA5A14 /* AnnivVC.swift */; };
+		8D1C73C62183EE0D00DA5A14 /* Anniv.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D1C73C52183EE0D00DA5A14 /* Anniv.storyboard */; };
 		8D2507B621A44E860015A206 /* AccentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D2507B521A44E850015A206 /* AccentButton.swift */; };
 		8D3E561521BAAA840090E46E /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3E561421BAAA840090E46E /* AppInfo.swift */; };
-		8D42F605222AC4BE00F01A77 /* AnniversaryUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D42F604222AC4BE00F01A77 /* AnniversaryUtil.swift */; };
+		8D42F605222AC4BE00F01A77 /* AnnivUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D42F604222AC4BE00F01A77 /* AnnivUtil.swift */; };
 		8D4CBB1821C0001D009BA7C6 /* Gift.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D4CBB1721C0001D009BA7C6 /* Gift.storyboard */; };
 		8D4CBB1A21C002C3009BA7C6 /* GiftVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4CBB1921C002C3009BA7C6 /* GiftVC.swift */; };
 		8D4CBB1C21C1511F009BA7C6 /* GiftDAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4CBB1B21C1511F009BA7C6 /* GiftDAO.swift */; };
@@ -50,8 +50,8 @@
 		8D8559FA21B80B270033C7AA /* UserAccountVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8559F921B80B270033C7AA /* UserAccountVC.swift */; };
 		8D8559FC21B8A3380033C7AA /* UpdateEmailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8559FB21B8A3380033C7AA /* UpdateEmailVC.swift */; };
 		8D8559FE21B8A34F0033C7AA /* UpdateEmail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D8559FD21B8A34F0033C7AA /* UpdateEmail.storyboard */; };
-		8D910B4D21E19F5C00D072EA /* AnniversaryEdit.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D910B4C21E19F5C00D072EA /* AnniversaryEdit.storyboard */; };
-		8D910B4F21E1C55500D072EA /* AnniversaryEditVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D910B4E21E1C55500D072EA /* AnniversaryEditVC.swift */; };
+		8D910B4D21E19F5C00D072EA /* AnnivEdit.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D910B4C21E19F5C00D072EA /* AnnivEdit.storyboard */; };
+		8D910B4F21E1C55500D072EA /* AnnivEditVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D910B4E21E1C55500D072EA /* AnnivEditVC.swift */; };
 		8D910B5321E2307400D072EA /* InspectableBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D910B5221E2307400D072EA /* InspectableBarButtonItem.swift */; };
 		8D910B5521E239C000D072EA /* InspectableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D910B5421E239C000D072EA /* InspectableStackView.swift */; };
 		8DA747E621A7C1F6007E7F5B /* TabBar.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8DA747E521A7C1F6007E7F5B /* TabBar.storyboard */; };
@@ -72,15 +72,15 @@
 		8DBB365721C5CF67008282D0 /* GiftRecordVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBB365621C5CF67008282D0 /* GiftRecordVC.swift */; };
 		8DC1977621C66A25006B7802 /* GiftRecordTableVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC1977521C66A25006B7802 /* GiftRecordTableVC.swift */; };
 		8DC43FD821CFE39A00B911F2 /* InspectableTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC43FD721CFE39A00B911F2 /* InspectableTableViewCell.swift */; };
-		8DC43FDA21D061C900B911F2 /* AnniversaryDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC43FD921D061C900B911F2 /* AnniversaryDataModel.swift */; };
-		8DC43FDC21D3C6FF00B911F2 /* GiftRecordSelectAnniversary.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8DC43FDB21D3C6FF00B911F2 /* GiftRecordSelectAnniversary.storyboard */; };
-		8DC43FDE21D3C78F00B911F2 /* GiftRecordSelectAnniversaryVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC43FDD21D3C78F00B911F2 /* GiftRecordSelectAnniversaryVC.swift */; };
+		8DC43FDA21D061C900B911F2 /* AnnivModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC43FD921D061C900B911F2 /* AnnivModel.swift */; };
+		8DC43FDC21D3C6FF00B911F2 /* GiftRecordSelectAnniv.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8DC43FDB21D3C6FF00B911F2 /* GiftRecordSelectAnniv.storyboard */; };
+		8DC43FDE21D3C78F00B911F2 /* GiftRecordSelectAnnivVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC43FDD21D3C78F00B911F2 /* GiftRecordSelectAnnivVC.swift */; };
 		8DC43FE021D3CC2900B911F2 /* GiftRecordSelectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC43FDF21D3CC2900B911F2 /* GiftRecordSelectProtocol.swift */; };
 		8DC43FE421D9F53600B911F2 /* GiftDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC43FE321D9F53600B911F2 /* GiftDataModel.swift */; };
 		8DD474B421C947CD00DD5919 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD474B321C947CD00DD5919 /* String+.swift */; };
 		8DD474B621CBEB4F00DD5919 /* GiftRecordSelectPersonVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD474B521CBEB4F00DD5919 /* GiftRecordSelectPersonVC.swift */; };
 		8DD474B821CBEB6D00DD5919 /* GiftRecordSelectPerson.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8DD474B721CBEB6D00DD5919 /* GiftRecordSelectPerson.storyboard */; };
-		8DD486F221E254E70072983A /* AnniversaryEditTableVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD486F121E254E70072983A /* AnniversaryEditTableVC.swift */; };
+		8DD486F221E254E70072983A /* AnnivEditTableVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD486F121E254E70072983A /* AnnivEditTableVC.swift */; };
 		8DD486F421EAD68D0072983A /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD486F321EAD68D0072983A /* Migration.swift */; };
 		8DE5A1F321F7552F0019201B /* DateDifferenceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE5A1F221F7552F0019201B /* DateDifferenceCalculator.swift */; };
 		8DEB3D7221DE42FF000AA2BC /* InspectableTabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DEB3D7121DE42FF000AA2BC /* InspectableTabBarItem.swift */; };
@@ -101,22 +101,22 @@
 		8D0FB84A2182002800BFCB79 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Resources/Info.plist; sourceTree = "<group>"; };
 		8D0FB8502182013E00BFCB79 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../Resources/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8D0FB8532182068100BFCB79 /* ContactAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactAccess.swift; sourceTree = "<group>"; };
-		8D0FB85521821B3B00BFCB79 /* AnniversaryDAO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryDAO.swift; sourceTree = "<group>"; };
+		8D0FB85521821B3B00BFCB79 /* AnnivDAO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnivDAO.swift; sourceTree = "<group>"; };
 		8D11B3B02193B94200C60371 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		8D11B3B32193EE4F00C60371 /* IconImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconImageView.swift; sourceTree = "<group>"; };
 		8D11B3B821940BD100C60371 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8D11B3BA21940BF600C60371 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
-		8D11B3BB2194431100C60371 /* AnniversaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryCell.swift; sourceTree = "<group>"; };
+		8D11B3BB2194431100C60371 /* AnnivCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnivCell.swift; sourceTree = "<group>"; };
 		8D11B3C021947EAF00C60371 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		8D11B3C22195C5CC00C60371 /* AnniversaryDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AnniversaryDetail.storyboard; sourceTree = "<group>"; };
-		8D11B3C42195CBF300C60371 /* AnniversaryDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryDetailVC.swift; sourceTree = "<group>"; };
+		8D11B3C22195C5CC00C60371 /* AnnivDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AnnivDetail.storyboard; sourceTree = "<group>"; };
+		8D11B3C42195CBF300C60371 /* AnnivDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnivDetailVC.swift; sourceTree = "<group>"; };
 		8D11B3C6219719B800C60371 /* TagLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagLabel.swift; sourceTree = "<group>"; };
 		8D1BFBB12185C6870082C766 /* DateTimeFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeFormat.swift; sourceTree = "<group>"; };
-		8D1C73C22183ED6C00DA5A14 /* AnniversaryVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryVC.swift; sourceTree = "<group>"; };
-		8D1C73C52183EE0D00DA5A14 /* Anniversary.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Anniversary.storyboard; path = "Memoria-iOS/Classes/Views/Anniversary.storyboard"; sourceTree = SOURCE_ROOT; };
+		8D1C73C22183ED6C00DA5A14 /* AnnivVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnivVC.swift; sourceTree = "<group>"; };
+		8D1C73C52183EE0D00DA5A14 /* Anniv.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Anniv.storyboard; path = "Memoria-iOS/Classes/Views/Anniv.storyboard"; sourceTree = SOURCE_ROOT; };
 		8D2507B521A44E850015A206 /* AccentButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentButton.swift; sourceTree = "<group>"; };
 		8D3E561421BAAA840090E46E /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
-		8D42F604222AC4BE00F01A77 /* AnniversaryUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryUtil.swift; sourceTree = "<group>"; };
+		8D42F604222AC4BE00F01A77 /* AnnivUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnivUtil.swift; sourceTree = "<group>"; };
 		8D4CBB1721C0001D009BA7C6 /* Gift.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Gift.storyboard; sourceTree = "<group>"; };
 		8D4CBB1921C002C3009BA7C6 /* GiftVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftVC.swift; sourceTree = "<group>"; };
 		8D4CBB1B21C1511F009BA7C6 /* GiftDAO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftDAO.swift; sourceTree = "<group>"; };
@@ -135,8 +135,8 @@
 		8D8559F921B80B270033C7AA /* UserAccountVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccountVC.swift; sourceTree = "<group>"; };
 		8D8559FB21B8A3380033C7AA /* UpdateEmailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEmailVC.swift; sourceTree = "<group>"; };
 		8D8559FD21B8A34F0033C7AA /* UpdateEmail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = UpdateEmail.storyboard; sourceTree = "<group>"; };
-		8D910B4C21E19F5C00D072EA /* AnniversaryEdit.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AnniversaryEdit.storyboard; sourceTree = "<group>"; };
-		8D910B4E21E1C55500D072EA /* AnniversaryEditVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryEditVC.swift; sourceTree = "<group>"; };
+		8D910B4C21E19F5C00D072EA /* AnnivEdit.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AnnivEdit.storyboard; sourceTree = "<group>"; };
+		8D910B4E21E1C55500D072EA /* AnnivEditVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnivEditVC.swift; sourceTree = "<group>"; };
 		8D910B5221E2307400D072EA /* InspectableBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectableBarButtonItem.swift; sourceTree = "<group>"; };
 		8D910B5421E239C000D072EA /* InspectableStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectableStackView.swift; sourceTree = "<group>"; };
 		8DA747E521A7C1F6007E7F5B /* TabBar.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TabBar.storyboard; sourceTree = "<group>"; };
@@ -157,15 +157,15 @@
 		8DBB365621C5CF67008282D0 /* GiftRecordVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftRecordVC.swift; sourceTree = "<group>"; };
 		8DC1977521C66A25006B7802 /* GiftRecordTableVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftRecordTableVC.swift; sourceTree = "<group>"; };
 		8DC43FD721CFE39A00B911F2 /* InspectableTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectableTableViewCell.swift; sourceTree = "<group>"; };
-		8DC43FD921D061C900B911F2 /* AnniversaryDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryDataModel.swift; sourceTree = "<group>"; };
-		8DC43FDB21D3C6FF00B911F2 /* GiftRecordSelectAnniversary.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GiftRecordSelectAnniversary.storyboard; sourceTree = "<group>"; };
-		8DC43FDD21D3C78F00B911F2 /* GiftRecordSelectAnniversaryVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftRecordSelectAnniversaryVC.swift; sourceTree = "<group>"; };
+		8DC43FD921D061C900B911F2 /* AnnivModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnivModel.swift; sourceTree = "<group>"; };
+		8DC43FDB21D3C6FF00B911F2 /* GiftRecordSelectAnniv.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GiftRecordSelectAnniv.storyboard; sourceTree = "<group>"; };
+		8DC43FDD21D3C78F00B911F2 /* GiftRecordSelectAnnivVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftRecordSelectAnnivVC.swift; sourceTree = "<group>"; };
 		8DC43FDF21D3CC2900B911F2 /* GiftRecordSelectProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftRecordSelectProtocol.swift; sourceTree = "<group>"; };
 		8DC43FE321D9F53600B911F2 /* GiftDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftDataModel.swift; sourceTree = "<group>"; };
 		8DD474B321C947CD00DD5919 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		8DD474B521CBEB4F00DD5919 /* GiftRecordSelectPersonVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftRecordSelectPersonVC.swift; sourceTree = "<group>"; };
 		8DD474B721CBEB6D00DD5919 /* GiftRecordSelectPerson.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GiftRecordSelectPerson.storyboard; sourceTree = "<group>"; };
-		8DD486F121E254E70072983A /* AnniversaryEditTableVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryEditTableVC.swift; sourceTree = "<group>"; };
+		8DD486F121E254E70072983A /* AnnivEditTableVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnivEditTableVC.swift; sourceTree = "<group>"; };
 		8DD486F321EAD68D0072983A /* Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
 		8DE5A1F221F7552F0019201B /* DateDifferenceCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateDifferenceCalculator.swift; sourceTree = "<group>"; };
 		8DEB3D7121DE42FF000AA2BC /* InspectableTabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectableTabBarItem.swift; sourceTree = "<group>"; };
@@ -221,8 +221,7 @@
 				8D17325222334C12005CD22C /* Views */,
 				8D17325522334C13005CD22C /* Presenters */,
 			);
-			name = Classes;
-			path = "New Group";
+			path = Classes;
 			sourceTree = "<group>";
 		};
 		8D17325122334C12005CD22C /* Commons */ = {
@@ -260,14 +259,14 @@
 				8DAE856621A2FD520049063D /* WelcomContactVC.swift */,
 				8DA747E521A7C1F6007E7F5B /* TabBar.storyboard */,
 				8DA747EA21A7C728007E7F5B /* TabBarController.swift */,
-				8D1C73C52183EE0D00DA5A14 /* Anniversary.storyboard */,
-				8D1C73C22183ED6C00DA5A14 /* AnniversaryVC.swift */,
-				8D11B3BB2194431100C60371 /* AnniversaryCell.swift */,
-				8D11B3C22195C5CC00C60371 /* AnniversaryDetail.storyboard */,
-				8D11B3C42195CBF300C60371 /* AnniversaryDetailVC.swift */,
-				8D910B4C21E19F5C00D072EA /* AnniversaryEdit.storyboard */,
-				8D910B4E21E1C55500D072EA /* AnniversaryEditVC.swift */,
-				8DD486F121E254E70072983A /* AnniversaryEditTableVC.swift */,
+				8D1C73C52183EE0D00DA5A14 /* Anniv.storyboard */,
+				8D1C73C22183ED6C00DA5A14 /* AnnivVC.swift */,
+				8D11B3BB2194431100C60371 /* AnnivCell.swift */,
+				8D11B3C22195C5CC00C60371 /* AnnivDetail.storyboard */,
+				8D11B3C42195CBF300C60371 /* AnnivDetailVC.swift */,
+				8D910B4C21E19F5C00D072EA /* AnnivEdit.storyboard */,
+				8D910B4E21E1C55500D072EA /* AnnivEditVC.swift */,
+				8DD486F121E254E70072983A /* AnnivEditTableVC.swift */,
 				8D4CBB1721C0001D009BA7C6 /* Gift.storyboard */,
 				8D4CBB1921C002C3009BA7C6 /* GiftVC.swift */,
 				8D4CBB1D21C159C5009BA7C6 /* GiftRecord.storyboard */,
@@ -275,8 +274,8 @@
 				8DC1977521C66A25006B7802 /* GiftRecordTableVC.swift */,
 				8DD474B721CBEB6D00DD5919 /* GiftRecordSelectPerson.storyboard */,
 				8DD474B521CBEB4F00DD5919 /* GiftRecordSelectPersonVC.swift */,
-				8DC43FDB21D3C6FF00B911F2 /* GiftRecordSelectAnniversary.storyboard */,
-				8DC43FDD21D3C78F00B911F2 /* GiftRecordSelectAnniversaryVC.swift */,
+				8DC43FDB21D3C6FF00B911F2 /* GiftRecordSelectAnniv.storyboard */,
+				8DC43FDD21D3C78F00B911F2 /* GiftRecordSelectAnnivVC.swift */,
 				8DC43FDF21D3CC2900B911F2 /* GiftRecordSelectProtocol.swift */,
 				8DA747E821A7C26A007E7F5B /* Setting.storyboard */,
 				8D56B2A121A7DAE300B90BED /* SettingVC.swift */,
@@ -318,9 +317,9 @@
 		8D17325422334C12005CD22C /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				8D42F604222AC4BE00F01A77 /* AnniversaryUtil.swift */,
-				8DC43FD921D061C900B911F2 /* AnniversaryDataModel.swift */,
-				8D0FB85521821B3B00BFCB79 /* AnniversaryDAO.swift */,
+				8D42F604222AC4BE00F01A77 /* AnnivUtil.swift */,
+				8DC43FD921D061C900B911F2 /* AnnivModel.swift */,
+				8D0FB85521821B3B00BFCB79 /* AnnivDAO.swift */,
 				8DE5A1F221F7552F0019201B /* DateDifferenceCalculator.swift */,
 				8D4CBB1B21C1511F009BA7C6 /* GiftDAO.swift */,
 				8DC43FE321D9F53600B911F2 /* GiftDataModel.swift */,
@@ -346,8 +345,7 @@
 				8D11B3B921940BD100C60371 /* Localizable.strings */,
 				8D0FB8502182013E00BFCB79 /* GoogleService-Info.plist */,
 			);
-			name = Resources;
-			path = "New Group1";
+			path = Resources;
 			sourceTree = "<group>";
 		};
 		BC6767E9807FAE23F80305EF /* Pods */ = {
@@ -436,7 +434,7 @@
 				8DAE856521A2F6260049063D /* WelcomeContact.storyboard in Resources */,
 				8D77D17E21B28DA400CF673A /* SignIn.storyboard in Resources */,
 				8D0FB8492182002800BFCB79 /* LaunchScreen.storyboard in Resources */,
-				8D910B4D21E19F5C00D072EA /* AnniversaryEdit.storyboard in Resources */,
+				8D910B4D21E19F5C00D072EA /* AnnivEdit.storyboard in Resources */,
 				8D4CBB1E21C159C5009BA7C6 /* GiftRecord.storyboard in Resources */,
 				8D0FB8512182013E00BFCB79 /* GoogleService-Info.plist in Resources */,
 				8D8559FE21B8A34F0033C7AA /* UpdateEmail.storyboard in Resources */,
@@ -444,13 +442,13 @@
 				8D8559F821B80AF00033C7AA /* UserAccount.storyboard in Resources */,
 				8DAE856121A2EC6D0049063D /* Welcome.storyboard in Resources */,
 				8DA747E921A7C26A007E7F5B /* Setting.storyboard in Resources */,
-				8D1C73C62183EE0D00DA5A14 /* Anniversary.storyboard in Resources */,
+				8D1C73C62183EE0D00DA5A14 /* Anniv.storyboard in Resources */,
 				8D11B3BF21947EAF00C60371 /* InfoPlist.strings in Resources */,
 				8D4CBB1821C0001D009BA7C6 /* Gift.storyboard in Resources */,
-				8D11B3C32195C5CD00C60371 /* AnniversaryDetail.storyboard in Resources */,
+				8D11B3C32195C5CD00C60371 /* AnnivDetail.storyboard in Resources */,
 				8DA747E621A7C1F6007E7F5B /* TabBar.storyboard in Resources */,
 				8DB8105121A915850007BBC5 /* HiddenList.storyboard in Resources */,
-				8DC43FDC21D3C6FF00B911F2 /* GiftRecordSelectAnniversary.storyboard in Resources */,
+				8DC43FDC21D3C6FF00B911F2 /* GiftRecordSelectAnniv.storyboard in Resources */,
 				8D0FB8462182002800BFCB79 /* Assets.xcassets in Resources */,
 				8D0FB8442182002700BFCB79 /* Main.storyboard in Resources */,
 			);
@@ -531,29 +529,29 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DB8105521A942E90007BBC5 /* InspectableButton.swift in Sources */,
-				8D0FB85621821B3B00BFCB79 /* AnniversaryDAO.swift in Sources */,
+				8D0FB85621821B3B00BFCB79 /* AnnivDAO.swift in Sources */,
 				8D56B2A221A7DAE300B90BED /* SettingVC.swift in Sources */,
 				8DB8105721AA8E510007BBC5 /* InspectableTextField.swift in Sources */,
 				8D56B2A421A85A7900B90BED /* OpenOtherApp.swift in Sources */,
 				8DEB3D7221DE42FF000AA2BC /* InspectableTabBarItem.swift in Sources */,
-				8D11B3C52195CBF300C60371 /* AnniversaryDetailVC.swift in Sources */,
-				8DD486F221E254E70072983A /* AnniversaryEditTableVC.swift in Sources */,
+				8D11B3C52195CBF300C60371 /* AnnivDetailVC.swift in Sources */,
+				8DD486F221E254E70072983A /* AnnivEditTableVC.swift in Sources */,
 				8DBB365721C5CF67008282D0 /* GiftRecordVC.swift in Sources */,
 				8D77D18021B2ABD100CF673A /* SignInVC.swift in Sources */,
 				8DC43FD821CFE39A00B911F2 /* InspectableTableViewCell.swift in Sources */,
 				8D11B3B42193EE4F00C60371 /* IconImageView.swift in Sources */,
 				8DB8105D21AC243B0007BBC5 /* ZodiacSign.swift in Sources */,
 				8D4CBB2321C51F7E009BA7C6 /* InspectableTextView.swift in Sources */,
-				8D11B3BC2194431100C60371 /* AnniversaryCell.swift in Sources */,
+				8D11B3BC2194431100C60371 /* AnnivCell.swift in Sources */,
 				8D4CBB2121C2A73A009BA7C6 /* InspectableNavItem.swift in Sources */,
 				8D3E561521BAAA840090E46E /* AppInfo.swift in Sources */,
 				8DB8105921AA97880007BBC5 /* InspectableSegmentedControl.swift in Sources */,
 				8DC43FE421D9F53600B911F2 /* GiftDataModel.swift in Sources */,
 				8D2507B621A44E860015A206 /* AccentButton.swift in Sources */,
 				8DB8105321A915B20007BBC5 /* HiddenListVC.swift in Sources */,
-				8D42F605222AC4BE00F01A77 /* AnniversaryUtil.swift in Sources */,
+				8D42F605222AC4BE00F01A77 /* AnnivUtil.swift in Sources */,
 				8DAE856321A2F1B90049063D /* InspectableLabel.swift in Sources */,
-				8DC43FDE21D3C78F00B911F2 /* GiftRecordSelectAnniversaryVC.swift in Sources */,
+				8DC43FDE21D3C78F00B911F2 /* GiftRecordSelectAnnivVC.swift in Sources */,
 				8DD486F421EAD68D0072983A /* Migration.swift in Sources */,
 				8D77D18521B37BED00CF673A /* PasswordlessVC.swift in Sources */,
 				8D4CBB1C21C1511F009BA7C6 /* GiftDAO.swift in Sources */,
@@ -562,7 +560,7 @@
 				8DC43FE021D3CC2900B911F2 /* GiftRecordSelectProtocol.swift in Sources */,
 				8D8559FC21B8A3380033C7AA /* UpdateEmailVC.swift in Sources */,
 				8D8559FA21B80B270033C7AA /* UserAccountVC.swift in Sources */,
-				8D910B4F21E1C55500D072EA /* AnniversaryEditVC.swift in Sources */,
+				8D910B4F21E1C55500D072EA /* AnnivEditVC.swift in Sources */,
 				8D0FB83F2182002700BFCB79 /* AppDelegate.swift in Sources */,
 				8D1BFBB22185C6870082C766 /* DateTimeFormat.swift in Sources */,
 				8DD474B621CBEB4F00DD5919 /* GiftRecordSelectPersonVC.swift in Sources */,
@@ -576,8 +574,8 @@
 				8DC1977621C66A25006B7802 /* GiftRecordTableVC.swift in Sources */,
 				8DA7BF4D2184D747004DF508 /* DialogBox.swift in Sources */,
 				8DE5A1F321F7552F0019201B /* DateDifferenceCalculator.swift in Sources */,
-				8DC43FDA21D061C900B911F2 /* AnniversaryDataModel.swift in Sources */,
-				8D1C73C32183ED6C00DA5A14 /* AnniversaryVC.swift in Sources */,
+				8DC43FDA21D061C900B911F2 /* AnnivModel.swift in Sources */,
+				8D1C73C32183ED6C00DA5A14 /* AnnivVC.swift in Sources */,
 				8D910B5521E239C000D072EA /* InspectableStackView.swift in Sources */,
 				8D11B3C7219719B800C60371 /* TagLabel.swift in Sources */,
 				8DD474B421C947CD00DD5919 /* String+.swift in Sources */,

--- a/Memoria-iOS/Classes/Commons/ContactAccess.swift
+++ b/Memoria-iOS/Classes/Commons/ContactAccess.swift
@@ -14,13 +14,6 @@ class ContactAccess {
     
     /// Taptic Engine
     var feedbackGenerator: UINotificationFeedbackGenerator?
-
-    // 連絡先のデータを格納するリスト
-    private var data: [String: [Any]]?
-    private var name: [String]?
-    private var birthday: [Date]?
-    private var anniversary: [Date]?
-    private var image: [UIImage]?
     
     // 連絡先を取得するクラスのインスタンス
     let store = CNContactStore.init()
@@ -116,7 +109,7 @@ class ContactAccess {
                 print("\(contact.familyName, contact.givenName)の誕生日がnilだったため処理を終了します")
                 return
             }
-            let birthday = AnniversaryDataModel(id: contact.identifier,
+            let birthday = AnnivModel(id: contact.identifier,
                                                 category: .birthday,
                                                 title: nil,
                                                 familyName: contact.familyName,
@@ -129,7 +122,7 @@ class ContactAccess {
                                                 memo: "")
             
             // データベースに連絡先の誕生日情報を保存する
-            AnniversaryDAO.set(documentPath: contact.identifier, data: birthday.toDictionary)
+            AnnivDAO.set(documentPath: contact.identifier, data: birthday.toDictionary)
         }
         // 取得した連絡先情報の件数をコールバックで返す
         if let callback = callback {

--- a/Memoria-iOS/Classes/Commons/Migration.swift
+++ b/Memoria-iOS/Classes/Commons/Migration.swift
@@ -33,10 +33,10 @@ struct Migration {
             DialogBox.showAlertWithIndicator(on: rootVC, message: "startMigration".localized) {
                 // ☆ isHiddenしかないドキュメントを消すマイグレーションが必要
                 // ① まず、非表示フラグがtrueのデータを検索し、非表示フラグをすべてNullにする
-                AnniversaryDAO.update(searchField: "isHidden", isEqualTo: true, updateField: "isHidden", turns: NSNull()) {
+                AnnivDAO.update(searchField: "isHidden", isEqualTo: true, updateField: "isHidden", turns: NSNull()) {
                     print("Ver.2.1.0 のisHiddenマイグレーションを開始")
                     // ② 非表示フラグがNullかつ、idがある記念日を検索
-                    AnniversaryDAO.getQuery(whereField: "isHidden", equalTo: NSNull())?.whereField("id", isGreaterThan: "").getDocuments { (query, error) in
+                    AnnivDAO.getQuery(whereField: "isHidden", equalTo: NSNull())?.whereField("id", isGreaterThan: "").getDocuments { (query, error) in
                         if let error = error {
                             print("Ver.2.1.0 のisHiddenマイグレーション中にエラー発生: \(error)")
                             DialogBox.dismissAlertWithIndicator(on: rootVC, completion: nil)
@@ -51,7 +51,7 @@ struct Migration {
                         DialogBox.updateAlert(with: "nextMigration".localized, on: rootVC) {
                             // ☆ 二つに分けた誕生日を一つにまとめる
                             // ① 非表示ではない記念日を検索
-                            AnniversaryDAO.getFilteredDocuments(whereField: "isHidden", equalTo: false) { (query) in
+                            AnnivDAO.getFilteredDocuments(whereField: "isHidden", equalTo: false) { (query) in
                                 print("Ver.2.1.0 の誕生日タイプマイグレーションを開始")
                                 guard query.count > 0 else {
                                     print("queryが空っぽです")
@@ -75,13 +75,13 @@ struct Migration {
                                     switch category {
                                     case "contactBirthday":
                                         print("\(id) is 'Contact birthday', Migrate to the 'birthday'")
-                                        AnniversaryDAO.update(anniversaryId: id, field: "category", content: "birthday")
-                                        AnniversaryDAO.update(anniversaryId: id, field: "isFromContact", content: true)
+                                        AnnivDAO.update(with: id, field: "category", content: "birthday")
+                                        AnnivDAO.update(with: id, field: "isFromContact", content: true)
                                         
                                     case "manualBirthday":
                                         print("\(id) is 'Manual birthday', Migrate to the 'birthday'")
-                                        AnniversaryDAO.update(anniversaryId: id, field: "category", content: "birthday")
-                                        AnniversaryDAO.update(anniversaryId: id, field: "isFromContact", content: false)
+                                        AnnivDAO.update(with: id, field: "category", content: "birthday")
+                                        AnnivDAO.update(with: id, field: "isFromContact", content: false)
                                         
                                     case "birthday":
                                         print("\(id) is 'birthday', Migration is unnecessary")
@@ -91,10 +91,10 @@ struct Migration {
                                         fallthrough
                                     default:
                                         print("\(id) is 'Other anniversary', Add new properties")
-                                        AnniversaryDAO.update(anniversaryId: id, field: "isFromContact", content: false)
+                                        AnnivDAO.update(with: id, field: "isFromContact", content: false)
                                     }
                                     // ③ isAnnualyとmemoはすべてのタイプで更新する
-                                    AnniversaryDAO.anniversaryCollection.document(id)
+                                    AnnivDAO.annivCollection.document(id)
                                         .updateData(["isAnnualy": true, "memo": ""]) { error in
                                         if let error = error {
                                             DialogBox.dismissAlertWithIndicator(on: rootVC, completion: nil)

--- a/Memoria-iOS/Classes/Models/AnnivDAO.swift
+++ b/Memoria-iOS/Classes/Models/AnnivDAO.swift
@@ -1,5 +1,5 @@
 //
-//  AnniversaryDAO.swift
+//  AnnivDAO.swift
 //  Memoria-iOS
 //
 //  Created by 村松龍之介 on 2018/10/26.
@@ -7,11 +7,10 @@
 //
 
 import UIKit
-
 import Firebase
 
 /// データベースへのアクセスを担うクラス
-class AnniversaryDAO {
+class AnnivDAO {
     
     // MARK: - プロパティ
     
@@ -21,7 +20,7 @@ class AnniversaryDAO {
     private static let uid = Auth.auth().currentUser?.uid
     // Unique collection
     private static let usersCollection = db.collection("users")
-    static let anniversaryCollection = usersCollection.document(uid!).collection("anniversary")
+    static let annivCollection = usersCollection.document(uid!).collection("anniversary")
 
 
     // MARK: - データ取得
@@ -31,8 +30,8 @@ class AnniversaryDAO {
     /// - Parameter:
     ///   - id: 記念日ID
     ///   - callback: ドキュメントのデータを受け取る
-    static func getAll(callback: @escaping ([AnniversaryDataModel]) -> Void) {
-        anniversaryCollection.getDocuments { (querySnapshot, error) in
+    static func getAll(callback: @escaping ([AnnivModel]) -> Void) {
+        annivCollection.getDocuments { (querySnapshot, error) in
             if let error = error {
                 print("エラー発生: \(error)")
             } else {
@@ -42,9 +41,9 @@ class AnniversaryDAO {
             var anniversarysArray = [[String: Any]]()
             
             querySnapshot?.documents.forEach { anniversarysArray.append($0.data()) }
-            let anniversaryData = anniversarysArray.map { AnniversaryDataModel(dictionary: $0)}
+            let anniversaryData = anniversarysArray.map { AnnivModel(dictionary: $0)}
             
-            callback(anniversaryData as! [AnniversaryDataModel])
+            callback(anniversaryData as! [AnnivModel])
         }
 //        { (document, error) in
 //            if let error = error {
@@ -64,12 +63,12 @@ class AnniversaryDAO {
     /// - Parameter:
     ///   - id: 記念日ID
     ///   - callback: ドキュメントのデータを受け取る
-    static func get(by anniversaryId: String, callback: @escaping ([String: Any]) -> Void) {
-        anniversaryCollection.document(anniversaryId).getDocument { (document, error) in
+    static func get(by id: String, callback: @escaping ([String: Any]) -> Void) {
+        annivCollection.document(id).getDocument { (document, error) in
             if let error = error {
                 print("エラー発生: \(error)")
             } else {
-                print("\(#function)の実行に成功:", anniversaryId)
+                print("\(#function)の実行に成功:", id)
             }
             // ドキュメントのアンラップと存在チェック
             if let document = document, document.exists {
@@ -85,7 +84,7 @@ class AnniversaryDAO {
     ///   - equalTo: 検索条件
     /// - Returns: 検索結果
     static func getQuery(whereField: String, equalTo: Any) -> Query? {
-        return anniversaryCollection.whereField(whereField, isEqualTo: equalTo)
+        return annivCollection.whereField(whereField, isEqualTo: equalTo)
     }
     
     /// getAnniversaryQuery()の検索結果ドキュメントを取得する
@@ -135,9 +134,9 @@ class AnniversaryDAO {
     ///   - data: 登録するデータ
     ///   - marge: 既存のドキュメントにデータを統合するか否か
     static func set(documentPath: String,
-                 data: AnniversaryDataModel,
+                 data: AnnivModel,
                  merge: Bool = true) {
-            anniversaryCollection.document(documentPath).setData(data.toDictionary, merge: merge) { error in
+            annivCollection.document(documentPath).setData(data.toDictionary, merge: merge) { error in
                     if let error = error {
                         print("エラー発生: \(error)")
                     } else {
@@ -155,7 +154,7 @@ class AnniversaryDAO {
     static func set(documentPath: String,
                     data: [String: Any],
                     merge: Bool = true) {
-        anniversaryCollection.document(documentPath).setData(data, merge: merge) { error in
+        annivCollection.document(documentPath).setData(data, merge: merge) { error in
             if let error = error {
                 print("エラー発生: \(error)")
             } else {
@@ -173,12 +172,12 @@ class AnniversaryDAO {
     ///   - documentPath: 一意のID
     ///   - field: 更新データ名
     ///   - content: 更新データ内容
-    static func update(anniversaryId: String, field: String, content: Any) {
-        anniversaryCollection.document(anniversaryId).updateData([field: content]) { error in
+    static func update(with id: String, field: String, content: Any) {
+        annivCollection.document(id).updateData([field: content]) { error in
             if let error = error {
                 print("エラー発生: \(error)")
             } else {
-                print("\(#function)の実行に成功:", anniversaryId)
+                print("\(#function)の実行に成功:", id)
             }
         }
     }
@@ -195,7 +194,7 @@ class AnniversaryDAO {
                        updateField: String,
                        turns content: Any,
                        callback: (() -> Void)?) {
-        anniversaryCollection.whereField(searchField, isEqualTo: true).getDocuments { (query, error) in
+        annivCollection.whereField(searchField, isEqualTo: true).getDocuments { (query, error) in
             if let error = error {
                 print("エラー発生: \(error)")
             } else {
@@ -222,7 +221,7 @@ class AnniversaryDAO {
                        updateField: String,
                        turns content: Any,
                        callback: (() -> Void)?) {
-        anniversaryCollection.whereField(searchField, isEqualTo: true)
+        annivCollection.whereField(searchField, isEqualTo: true)
             .whereField(secondSearchField, isEqualTo: secondIsEqualTo).getDocuments { (query, error) in
             if let error = error {
                 print("エラー発生: \(error)")
@@ -244,12 +243,12 @@ class AnniversaryDAO {
     /// - Parameters:
     ///   - whereField: 検索対象
     ///   - equalTo: 検索条件
-    static func deleteAnniversary(documentPath: String) {
-        anniversaryCollection.document(documentPath).delete() { error in
+    static func delete(with id: String) {
+        annivCollection.document(id).delete() { error in
             if let error = error {
                 print("エラー発生: \(error)")
             } else {
-                print("\(#function)の実行に成功:", documentPath)
+                print("\(#function)の実行に成功:", id)
             }
         }
     }
@@ -259,9 +258,9 @@ class AnniversaryDAO {
     /// - Parameters:
     ///   - whereField: 検索対象
     ///   - equalTo: 検索条件
-    static func deleteQueryAnniversary(whereField: String, equalTo: Any,
+    static func deleteByQuery(with whereField: String, isEqualTo: Any,
                                 on roorVC: UIViewController, compltion: (() -> Void)? = nil) {
-        anniversaryCollection.whereField(whereField, isEqualTo: equalTo).getDocuments { (querySnapshot, error) in
+        annivCollection.whereField(whereField, isEqualTo: isEqualTo).getDocuments { (querySnapshot, error) in
             // Instantiate a new feedback-generator
             let feedbackGenerator = UINotificationFeedbackGenerator()
             feedbackGenerator.prepare()

--- a/Memoria-iOS/Classes/Models/AnnivModel.swift
+++ b/Memoria-iOS/Classes/Models/AnnivModel.swift
@@ -1,5 +1,5 @@
 //
-//  AnniversaryDataModel.swift
+//  AnnivModel.swift
 //  Memoria-iOS
 //
 //  Created by 村松龍之介 on 2018/12/24.
@@ -10,14 +10,14 @@ import Foundation
 import Firebase
 
 // MARK: - Enum
-enum AnniversaryType: Int, CustomStringConvertible {
-    case anniversary
+enum AnnivType: Int, CustomStringConvertible {
+    case anniv
     case birthday
     
     init(category: String) {
         switch category{
         case "anniversary":
-            self = .anniversary
+            self = .anniv
             
         case "birthday":
              self = .birthday
@@ -30,16 +30,16 @@ enum AnniversaryType: Int, CustomStringConvertible {
     
     var description: String {
         switch self {
-        case .anniversary: return "anniversary"
+        case .anniv: return "anniversary"
         case .birthday: return "birthday"
         }
     }
 }
 
 /// 記念日データのモデル
-struct AnniversaryDataModel {
+struct AnnivModel {
     let id: String
-    let category: AnniversaryType
+    let category: AnnivType
     let title: String?
     let familyName: String?
     let givenName: String?
@@ -72,14 +72,14 @@ struct AnniversaryDataModel {
     }
 }
 
-extension AnniversaryDataModel {
+extension AnnivModel {
     
     // 辞書型データからデータモデルを作る
     init?(dictionary: [String: Any]) {
         guard let category = dictionary["category"] as? String else { return nil }
         
         self.id = dictionary["id"] as! String
-        self.category = AnniversaryType(category: category)
+        self.category = AnnivType(category: category)
         self.title = dictionary["title"] as? String
         self.familyName = dictionary["familyName"] as? String
         self.givenName = dictionary["givenName"] as? String

--- a/Memoria-iOS/Classes/Models/AnnivUtil.swift
+++ b/Memoria-iOS/Classes/Models/AnnivUtil.swift
@@ -1,5 +1,5 @@
 //
-//  AnniversaryUtil.swift
+//  AnnivUtil.swift
 //  Memoria-iOS
 //
 //  Created by 村松龍之介 on 2019/03/02.
@@ -8,23 +8,23 @@
 
 import UIKit
 
-struct AnniversaryUtil {
+struct AnnivUtil {
     /// 記念日か誕生日かによってタイトルが違うので、ここで判断して返す
     ///
     /// - Parameter anniversary: 記念日データ
     /// - Returns: 記念日名か、人名を文字列で返却
-    static func getName(from anniversary: [String : Any]) -> String? {
+    static func getName(from anniv: [String : Any]) -> String? {
         // 記念日の分類
-        let category = AnniversaryType(category: anniversary["category"] as! String)
+        let category = AnnivType(category: anniv["category"] as! String)
         // 記念日の名称。誕生日だったら苗字と名前を繋げて表示
         switch category {
-        case .anniversary:
-            return anniversary["title"] as? String
+        case .anniv:
+            return anniv["title"] as? String
             
         case .birthday:
             return String(format: "whoseBirthday".localized,
-                          arguments: [anniversary["familyName"] as! String,
-                                      anniversary["givenName"] as! String])
+                          arguments: [anniv["familyName"] as! String,
+                                      anniv["givenName"] as! String])
         }
     }
     
@@ -43,13 +43,13 @@ struct AnniversaryUtil {
     ///
     /// - Parameter anniversary: 記念日データ
     /// - Returns: 登録済みデータで作ったアイコン画像か、デフォルト画像を返す
-    static func getIconImage(from anniversary: [String : Any]) -> UIImage {
-        if let iconImageData = anniversary["iconImage"] as? Data,
+    static func getIconImage(from anniv: [String : Any]) -> UIImage {
+        if let iconImageData = anniv["iconImage"] as? Data,
             let iconImage = UIImage(data: iconImageData) {
             return iconImage
         } else {
             // 記念日の分類
-            let category = AnniversaryType(category: anniversary["category"] as! String)
+            let category = AnnivType(category: anniv["category"] as! String)
             // アイコンがない場合はデフォルトアイコンを使用
             return category == .birthday
                 ? #imageLiteral(resourceName: "Ribbon") // 誕生日

--- a/Memoria-iOS/Classes/Models/GiftDataModel.swift
+++ b/Memoria-iOS/Classes/Models/GiftDataModel.swift
@@ -14,7 +14,7 @@ struct GiftDataModel {
     let id: String
     let isReceived: Bool
     let personName: String
-    let anniversaryName: String
+    let annivName: String
     let date: Timestamp?
     let goods: String
     let memo: String
@@ -28,7 +28,7 @@ struct GiftDataModel {
         dictionary["id"] = id
         dictionary["isReceived"] = isReceived
         dictionary["personName"] = personName
-        dictionary["anniversaryName"] = anniversaryName
+        dictionary["anniversaryName"] = annivName
         dictionary["date"] = date ?? NSNull()
         dictionary["goods"] = goods
         dictionary["memo"] = memo

--- a/Memoria-iOS/Classes/Views/Anniv.storyboard
+++ b/Memoria-iOS/Classes/Views/Anniv.storyboard
@@ -13,7 +13,7 @@
         <!--Anniversary-->
         <scene sceneID="F59-UR-Zbt">
             <objects>
-                <collectionViewController id="sES-Td-IIs" customClass="AnniversaryVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <collectionViewController id="sES-Td-IIs" customClass="AnnivVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="GR3-AA-OB8">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -47,7 +47,7 @@
                             </constraints>
                         </view>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="anniversaryCell" id="be1-Rq-g1l" customClass="AnniversaryCell" customModule="Memoria_iOS" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="anniversaryCell" id="be1-Rq-g1l" customClass="AnnivCell" customModule="Memoria_iOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="161" height="90"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
@@ -71,7 +71,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="RemainingDays" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="60m-3V-zWw" customClass="TagLabel" customModule="Memoria_iOS" customModuleProvider="target">
-                                                            <rect key="frame" x="34.5" y="13.5" width="114.5" height="19.5"/>
+                                                            <rect key="frame" x="37.5" y="13.5" width="111.5" height="19.5"/>
                                                             <color key="backgroundColor" red="0.91928410530090332" green="0.58592182397842407" blue="0.26450419425964355" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -117,9 +117,9 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <outlet property="anniversaryDateLabel" destination="opE-H9-apJ" id="vRC-wp-Hda"/>
-                                    <outlet property="anniversaryIconImage" destination="7lE-sw-m9w" id="6ZO-GZ-S1i"/>
-                                    <outlet property="anniversaryNameLabel" destination="HNi-0C-mqs" id="shl-Hn-Tqs"/>
+                                    <outlet property="annivDateLabel" destination="opE-H9-apJ" id="vRC-wp-Hda"/>
+                                    <outlet property="annivIconImage" destination="7lE-sw-m9w" id="6ZO-GZ-S1i"/>
+                                    <outlet property="annivNameLabel" destination="HNi-0C-mqs" id="shl-Hn-Tqs"/>
                                     <outlet property="remainingDaysLabel" destination="60m-3V-zWw" id="aWa-eL-zJx"/>
                                     <segue destination="7kk-Fl-mow" kind="show" identifier="toDetailSegue" id="b46-oi-PmK"/>
                                 </connections>
@@ -173,18 +173,18 @@
             </objects>
             <point key="canvasLocation" x="76" y="80"/>
         </scene>
-        <!--AnniversaryDetail-->
+        <!--AnnivDetail-->
         <scene sceneID="LQA-2e-eJr">
             <objects>
-                <viewControllerPlaceholder storyboardName="AnniversaryDetail" id="7kk-Fl-mow" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="AnnivDetail" id="7kk-Fl-mow" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="40w-7g-lFc" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1517" y="160"/>
         </scene>
-        <!--AnniversaryEdit-->
+        <!--AnnivEdit-->
         <scene sceneID="e3y-sp-VVx">
             <objects>
-                <viewControllerPlaceholder storyboardName="AnniversaryEdit" id="Z4Z-aK-Pdu" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="AnnivEdit" id="Z4Z-aK-Pdu" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="85K-y8-ll0" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1359" y="-135"/>

--- a/Memoria-iOS/Classes/Views/AnnivCell.swift
+++ b/Memoria-iOS/Classes/Views/AnnivCell.swift
@@ -1,5 +1,5 @@
 //
-//  AnniversaryCell.swift
+//  AnnivCell.swift
 //  Memoria-iOS
 //
 //  Created by 村松龍之介 on 2018/11/08.
@@ -8,20 +8,20 @@
 
 import UIKit
 
-final class AnniversaryCell: UICollectionViewCell {
+final class AnnivCell: UICollectionViewCell {
     
-    @IBOutlet weak var anniversaryNameLabel: UILabel!
-    @IBOutlet weak var anniversaryDateLabel: UILabel!
+    @IBOutlet weak var annivNameLabel: UILabel!
+    @IBOutlet weak var annivDateLabel: UILabel!
     @IBOutlet weak var remainingDaysLabel: TagLabel!
-    @IBOutlet weak var anniversaryIconImage: IconImageView!
+    @IBOutlet weak var annivIconImage: IconImageView!
     
     /// セル再利用の準備
     override func prepareForReuse() {
         super.prepareForReuse()
         
         // 色をリセットする
-        anniversaryNameLabel.textColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
-        anniversaryDateLabel.textColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
+        annivNameLabel.textColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
+        annivDateLabel.textColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
         backgroundColor = #colorLiteral(red: 0.8901960784, green: 0.8901960784, blue: 0.8901960784, alpha: 1)
         remainingDaysLabel.backgroundColor = #colorLiteral(red: 1, green: 0.6629999876, blue: 0.07800000161, alpha: 1)
         contentView.alpha = 1.0

--- a/Memoria-iOS/Classes/Views/AnnivDetail.storyboard
+++ b/Memoria-iOS/Classes/Views/AnnivDetail.storyboard
@@ -11,10 +11,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Anniversary DetailVC-->
+        <!--Anniv DetailVC-->
         <scene sceneID="KsI-AI-oqW">
             <objects>
-                <viewController id="lYt-3l-Q4d" customClass="AnniversaryDetailVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="lYt-3l-Q4d" customClass="AnnivDetailVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="lL8-lY-4WJ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -23,7 +23,7 @@
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="topCell" rowHeight="116" id="CvQ-rC-reh">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="topCell" rowHeight="116" id="CvQ-rC-reh">
                                         <rect key="frame" x="0.0" y="55.5" width="375" height="116"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="CvQ-rC-reh" id="xYM-qi-Tww">
@@ -76,7 +76,7 @@
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" name="mainColor"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="anniversaryDetailCell" textLabel="Bmy-Lm-aDX" detailTextLabel="62T-vY-izV" style="IBUITableViewCellStyleValue1" id="MxC-3V-yqD">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="annivDetailCell" textLabel="Bmy-Lm-aDX" detailTextLabel="62T-vY-izV" style="IBUITableViewCellStyleValue1" id="MxC-3V-yqD">
                                         <rect key="frame" x="0.0" y="171.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MxC-3V-yqD" id="Hr5-CE-ew1">
@@ -100,7 +100,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="giftCell" id="udm-0n-ErA">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="giftCell" id="udm-0n-ErA">
                                         <rect key="frame" x="0.0" y="215.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="udm-0n-ErA" id="bPB-ue-JRO">
@@ -199,10 +199,10 @@
             </objects>
             <point key="canvasLocation" x="-149.59999999999999" y="82.3088455772114"/>
         </scene>
-        <!--AnniversaryEdit-->
+        <!--AnnivEdit-->
         <scene sceneID="hGW-PJ-7s3">
             <objects>
-                <viewControllerPlaceholder storyboardName="AnniversaryEdit" id="C5v-MH-sGv" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="AnnivEdit" id="C5v-MH-sGv" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0MY-Vl-8av" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="386" y="-63"/>

--- a/Memoria-iOS/Classes/Views/AnnivDetailVC.swift
+++ b/Memoria-iOS/Classes/Views/AnnivDetailVC.swift
@@ -1,5 +1,5 @@
 //
-//  AnniversaryDetailVC.swift
+//  AnnivDetailVC.swift
 //  Memoria-iOS
 //
 //  Created by 村松龍之介 on 2018/11/09.
@@ -9,7 +9,7 @@
 import UIKit
 import Firebase
 
-final class AnniversaryDetailVC: UIViewController {
+final class AnnivDetailVC: UIViewController {
 
     // MARK: - Enum
     
@@ -22,10 +22,10 @@ final class AnniversaryDetailVC: UIViewController {
     
     @IBOutlet weak var tableView: UITableView!
     
-    /// AnniversaryVCから受け取るデータ
-    var anniversary: [String: Any]!
+    /// AnnivVCから受け取るデータ
+    var anniv: [String: Any]!
     
-    var category: AnniversaryType?
+    var category: AnnivType?
     
     var gifts: [[String: Any]]?
     var selectedGiftId: String?
@@ -34,7 +34,7 @@ final class AnniversaryDetailVC: UIViewController {
     var listenerRegistration: ListenerRegistration?
 
     // 次の画面に渡す用の記念日データを持っておく
-    var anniversaryData: AnniversaryDataModel?
+    var annivModel: AnnivModel?
 
     
     // MARK: - ライフサイクル
@@ -59,7 +59,7 @@ final class AnniversaryDetailVC: UIViewController {
 
     /// 記念日データ変更監視用リスナー登録
     private func registerListener() {
-        let filteredCollection = AnniversaryDAO.getQuery(whereField: "id", equalTo: anniversary["id"] as! String)
+        let filteredCollection = AnnivDAO.getQuery(whereField: "id", equalTo: anniv["id"] as! String)
         // anniversaryコレクションの変更を監視するリスナー登録
         listenerRegistration = filteredCollection?.addSnapshotListener { snapshot, error in
             print("AnniversaryDetailVCでリスナー登録")
@@ -68,20 +68,20 @@ final class AnniversaryDetailVC: UIViewController {
                 return
             }
             // 編集画面に渡す用のデータをセット
-            self.anniversaryData = AnniversaryDataModel(dictionary: anniversary)
+            self.annivModel = AnnivModel(dictionary: anniversary)
             // 記念日データから日付を取り出す
             if let date = (anniversary["date"] as? Timestamp)?.dateValue() {
                 let remainingDays = DateDifferenceCalculator.getDifference(from: date, isAnnualy: anniversary["isAnnualy"] as? Bool ?? true)
-                self.navigationItem.title = AnniversaryUtil.getRemainingDaysString(from: remainingDays)
+                self.navigationItem.title = AnnivUtil.getRemainingDaysString(from: remainingDays)
             }
             // テーブルのデータ更新のために渡す
-            self.anniversary = anniversary
+            self.anniv = anniversary
             
             guard let category = anniversary["category"] as? String else { return }
-            self.category = AnniversaryType(category: category)
+            self.category = AnnivType(category: category)
             
             switch self.category! {
-            case .anniversary:
+            case .anniv:
                 self.searchGift(with: anniversary["title"] as! String)
                 
             case .birthday:
@@ -109,8 +109,8 @@ final class AnniversaryDetailVC: UIViewController {
         
         if id == "editAnniversarySegue" {
             let navC = segue.destination as! UINavigationController
-            let nextVC = navC.topViewController as! AnniversaryEditVC
-            nextVC.anniversaryData = anniversaryData
+            let nextVC = navC.topViewController as! AnnivEditVC
+            nextVC.annivModel = annivModel
         }
         
         if id == "editGiftSegue" {
@@ -133,7 +133,7 @@ final class AnniversaryDetailVC: UIViewController {
         let whereField: String
         
         switch category {
-        case .anniversary:
+        case .anniv:
             whereField = "anniversaryName"
 
         case .birthday:
@@ -166,7 +166,7 @@ final class AnniversaryDetailVC: UIViewController {
 
 // MARK: - UITableView DataSource and Delegate
 
-extension AnniversaryDetailVC: UITableViewDataSource, UITableViewDelegate {
+extension AnnivDetailVC: UITableViewDataSource, UITableViewDelegate {
     /// セクションの数
     func numberOfSections(in tableView: UITableView) -> Int {
         return gifts == nil ? 1 : 2
@@ -177,7 +177,7 @@ extension AnniversaryDetailVC: UITableViewDataSource, UITableViewDelegate {
         switch Section(rawValue: section)! {
         case .topSection:
             if let category = category {
-                return category == .anniversary ? 1 : 3
+                return category == .anniv ? 1 : 3
             } else {
                 return 1
             }
@@ -194,17 +194,17 @@ extension AnniversaryDetailVC: UITableViewDataSource, UITableViewDelegate {
         
         let section = Section(rawValue: indexPath.section)!
         
-        let anniversaryDate = (anniversary["date"] as! Timestamp).dateValue()
+        let anniversaryDate = (anniv["date"] as! Timestamp).dateValue()
         
         switch (section, indexPath.row) {
         case (.topSection, 0):
             cell = tableView.dequeueReusableCell(withIdentifier: "topCell", for: indexPath)
             // 記念日のアイコン
             let imageView = cell.viewWithTag(1) as! UIImageView
-            imageView.image = AnniversaryUtil.getIconImage(from: anniversary)
+            imageView.image = AnnivUtil.getIconImage(from: anniv)
             // 記念日の名前
             let anniversaryNameLabel = cell.viewWithTag(2) as! UILabel
-            anniversaryNameLabel.text = AnniversaryUtil.getName(from: anniversary)
+            anniversaryNameLabel.text = AnnivUtil.getName(from: anniv)
             // 記念日の日程
             let anniversaryDateLabel = cell.viewWithTag(3) as! UILabel
             anniversaryDateLabel.text = DateTimeFormat.getYMDString(date: anniversaryDate)
@@ -213,7 +213,7 @@ extension AnniversaryDetailVC: UITableViewDataSource, UITableViewDelegate {
             cell = tableView.dequeueReusableCell(withIdentifier: "giftCell", for: indexPath)
             
         default:
-            cell = tableView.dequeueReusableCell(withIdentifier: "anniversaryDetailCell", for: indexPath)
+            cell = tableView.dequeueReusableCell(withIdentifier: "annivDetailCell", for: indexPath)
         }
         
         if let category = category {
@@ -239,7 +239,7 @@ extension AnniversaryDetailVC: UITableViewDataSource, UITableViewDelegate {
                 gotOrReceivedLabel.text = isReceived ? "gotGift".localized : "gaveGift".localized
                 gotOrReceivedLabel.backgroundColor = isReceived ? #colorLiteral(red: 1, green: 0.6629999876, blue: 0.07800000161, alpha: 1) : #colorLiteral(red: 0.3411764801, green: 0.6235294342, blue: 0.1686274558, alpha: 1)
                 
-            case (.anniversary, .giftSection, _):
+            case (.anniv, .giftSection, _):
                 let personNameLabel = cell.viewWithTag(2) as! UILabel
                 let goodsLabel = cell.viewWithTag(3) as! UILabel
                 let gotOrReceivedLabel = cell.viewWithTag(4) as! TagLabel
@@ -275,11 +275,11 @@ extension AnniversaryDetailVC: UITableViewDataSource, UITableViewDelegate {
         let section = Section(rawValue: section)!
         switch (section, category) {
         case (.topSection, _):
-            if let memo = anniversaryData?.memo, memo != "" {
+            if let memo = annivModel?.memo, memo != "" {
                 return "memo:".localized + memo
             }
             return nil
-        case (.giftSection, .anniversary): return "giftSectionFooterForAnniversary".localized
+        case (.giftSection, .anniv): return "giftSectionFooterForAnniversary".localized
         case (.giftSection, .birthday): return "giftSectionFooterForBirthday".localized
         }
     }

--- a/Memoria-iOS/Classes/Views/AnnivEdit.storyboard
+++ b/Memoria-iOS/Classes/Views/AnnivEdit.storyboard
@@ -1,26 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zxw-NY-r7d">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Anniversary EditVC-->
+        <!--Anniv EditVC-->
         <scene sceneID="fsU-19-kCK">
             <objects>
-                <viewController storyboardIdentifier="GiftRecordVC" id="CDS-0C-eHY" customClass="AnniversaryEditVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="GiftRecordVC" id="CDS-0C-eHY" customClass="AnnivEditVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="CPF-JW-H7q">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xn4-1s-ZnT">
-                                <rect key="frame" x="0.0" y="223" width="375" height="90"/>
+                                <rect key="frame" x="0.0" y="223" width="600" height="90"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="90" id="Hez-z0-1Ia"/>
                                 </constraints>
@@ -29,7 +25,7 @@
                                 </connections>
                             </containerView>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="SpR-bI-R5I" customClass="InspectableSegmentedControl" customModule="Memoria_iOS" customModuleProvider="target">
-                                <rect key="frame" x="112.5" y="82" width="150" height="29"/>
+                                <rect key="frame" x="225" y="82" width="150" height="29"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="jeo-Ix-jwd"/>
                                 </constraints>
@@ -43,11 +39,11 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="localizedStringKey2" value="birthday"/>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <action selector="toggleAnniversaryType:" destination="CDS-0C-eHY" eventType="valueChanged" id="hxX-hJ-VRz"/>
+                                    <action selector="toggleAnnivTypeTapped:" destination="CDS-0C-eHY" eventType="valueChanged" id="hxX-hJ-VRz"/>
                                 </connections>
                             </segmentedControl>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="interactive" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="NIa-Cw-DWR" customClass="InspectableTextView" customModule="Memoria_iOS" customModuleProvider="target">
-                                <rect key="frame" x="12" y="329" width="347" height="185"/>
+                                <rect key="frame" x="12" y="329" width="572" height="118"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -64,10 +60,10 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="1kt-Gh-au1" customClass="InspectableStackView" customModule="Memoria_iOS" customModuleProvider="target">
-                                <rect key="frame" x="16" y="158.5" width="343" height="44.5"/>
+                                <rect key="frame" x="16" y="158.5" width="568" height="44.5"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="unlessEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Y6a-G3-5nv" customClass="InspectableTextField" customModule="Memoria_iOS" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="106.5" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="181.5" height="44.5"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" returnKeyType="done"/>
@@ -80,7 +76,7 @@
                                         </connections>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="unlessEditing" translatesAutoresizingMaskIntoConstraints="NO" id="osb-jM-eE3" customClass="InspectableTextField" customModule="Memoria_iOS" customModuleProvider="target">
-                                        <rect key="frame" x="118.5" y="0.0" width="106" height="44.5"/>
+                                        <rect key="frame" x="193.5" y="0.0" width="181" height="44.5"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" returnKeyType="next"/>
@@ -93,7 +89,7 @@
                                         </connections>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="unlessEditing" translatesAutoresizingMaskIntoConstraints="NO" id="kR2-0O-kI4" customClass="InspectableTextField" customModule="Memoria_iOS" customModuleProvider="target">
-                                        <rect key="frame" x="236.5" y="0.0" width="106.5" height="44.5"/>
+                                        <rect key="frame" x="386.5" y="0.0" width="181.5" height="44.5"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" returnKeyType="done"/>
@@ -116,7 +112,7 @@
                                 </userDefinedRuntimeAttributes>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L1y-eR-Vh1" customClass="NegativeButton" customModule="Memoria_iOS" customModuleProvider="target">
-                                <rect key="frame" x="97.5" y="548" width="180" height="54"/>
+                                <rect key="frame" x="210" y="481" width="180" height="54"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="180" id="Ipu-Vh-vUp"/>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="54" id="n74-cV-HXK"/>
@@ -173,10 +169,10 @@
                     </navigationItem>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="anniversaryTitleField" destination="Y6a-G3-5nv" id="KP1-cL-fqF"/>
-                        <outlet property="anniversaryTypeChoice" destination="SpR-bI-R5I" id="OPj-kk-9x6"/>
-                        <outlet property="anniversaryTypeLabel" destination="OyB-St-2Xs" id="Y8x-nl-lZy"/>
-                        <outlet property="hideAnniversaryButton" destination="L1y-eR-Vh1" id="BJl-OH-VTZ"/>
+                        <outlet property="annivHideButton" destination="L1y-eR-Vh1" id="BJl-OH-VTZ"/>
+                        <outlet property="annivTitleField" destination="Y6a-G3-5nv" id="KP1-cL-fqF"/>
+                        <outlet property="annivTypeLabel" destination="OyB-St-2Xs" id="Y8x-nl-lZy"/>
+                        <outlet property="annivTypeSegment" destination="SpR-bI-R5I" id="OPj-kk-9x6"/>
                         <outlet property="leftNameField" destination="osb-jM-eE3" id="pje-hU-rmg"/>
                         <outlet property="memoView" destination="NIa-Cw-DWR" id="5DK-tS-TMF"/>
                         <outlet property="recordButton" destination="lKB-8f-uar" id="BSp-7f-VcN"/>
@@ -187,10 +183,10 @@
             </objects>
             <point key="canvasLocation" x="1080.8" y="132.68365817091455"/>
         </scene>
-        <!--Anniversary Edit TableVC-->
+        <!--Anniv Edit TableVC-->
         <scene sceneID="CjQ-mL-H9U">
             <objects>
-                <tableViewController id="TZb-Mu-70l" customClass="AnniversaryEditTableVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="TZb-Mu-70l" customClass="AnnivEditTableVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="45" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="LPf-tu-HfX">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="90"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Memoria-iOS/Classes/Views/AnnivEditTableVC.swift
+++ b/Memoria-iOS/Classes/Views/AnnivEditTableVC.swift
@@ -1,5 +1,5 @@
 //
-//  AnniversaryEditTableVC.swift
+//  AnnivEditTableVC.swift
 //  Memoria-iOS
 //
 //  Created by 村松龍之介 on 2019/01/07.
@@ -10,12 +10,12 @@ import UIKit
 import Firebase
 
 /// すべてのフィールドにテキストが入力されて登録ボタンを押せることを知らせる
-protocol AnniversaryEditTableVCDelegate: AnyObject {
+protocol AnnivEditTableVCDelegate: AnyObject {
     func needValidation(with enabled: Bool)
 }
 
 /// Anniversaryの情報を入力するためのテーブルVC
-class AnniversaryEditTableVC: UITableViewController {
+class AnnivEditTableVC: UITableViewController {
 
     // MARK: - Properties
 
@@ -27,7 +27,7 @@ class AnniversaryEditTableVC: UITableViewController {
     var timestamp: Timestamp?
     
     // 登録ボタンを押せることを知らせるプロトコルのデリゲートを宣言
-    weak var anniversaryEditTableVCDelegate: AnniversaryEditTableVCDelegate?
+    weak var annivEditTableVCDelegate: AnnivEditTableVCDelegate?
     
     
     // MARK: - Life cycle
@@ -47,7 +47,7 @@ class AnniversaryEditTableVC: UITableViewController {
 
     @IBAction private func toggleAnnualy(_ sender: UISwitch) {
         // 繰り返すか否かのスイッチ押下されたら、検証を求める
-        anniversaryEditTableVCDelegate?.needValidation(with: true)
+        annivEditTableVCDelegate?.needValidation(with: true)
     }
     
     // MARK: - Private Method
@@ -66,7 +66,7 @@ class AnniversaryEditTableVC: UITableViewController {
         dateField.text = DateTimeFormat.getYMDString(date: datePicker.date)
         // 登録時の日付参照用変数に日付情報を代入
         timestamp = Timestamp(date: datePicker.date)
-        anniversaryEditTableVCDelegate?.needValidation(with: true)
+        annivEditTableVCDelegate?.needValidation(with: true)
     }
     
     
@@ -113,13 +113,13 @@ class AnniversaryEditTableVC: UITableViewController {
 }
 
 // MARK: - Text field delegate
-extension AnniversaryEditTableVC: UITextFieldDelegate {
+extension AnnivEditTableVC: UITextFieldDelegate {
     /// クリアボタンが押されたら今日の日付を設定する
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
         let today = Date()
         datePicker.date = today
         timestamp = Timestamp(date: today)
-        anniversaryEditTableVCDelegate?.needValidation(with: true)
+        annivEditTableVCDelegate?.needValidation(with: true)
         return true
     }
 }

--- a/Memoria-iOS/Classes/Views/AnnivVC.swift
+++ b/Memoria-iOS/Classes/Views/AnnivVC.swift
@@ -1,5 +1,5 @@
 //
-//  AnniversaryVC.swift
+//  AnnivVC.swift
 //  Memoria-iOS
 //
 //  Created by 村松龍之介 on 2018/10/27.
@@ -10,7 +10,7 @@ import UIKit
 import Firebase
 
 /// 記念日一覧を表示するメイン画面のクラス
-final class AnniversaryVC: UICollectionViewController {
+final class AnnivVC: UICollectionViewController {
     
     // MARK: - IBOutlet property
 
@@ -22,9 +22,9 @@ final class AnniversaryVC: UICollectionViewController {
     /// リスナー登録
     var listenerRegistration: ListenerRegistration?
     /// 未来の日付、または繰り返す記念日
-    var notFinishedAnniversarys = [[String: Any]]()
+    var notFinishedAnnivs = [[String: Any]]()
     /// 繰り返さない記念日かつ、もう過ぎた記念日の数
-    var finishedAnniversarys = [[String: Any]]()
+    var finishedAnnivs = [[String: Any]]()
     
     // 引っ張って更新用のRefreshControl
     var refresher = UIRefreshControl()
@@ -83,13 +83,13 @@ final class AnniversaryVC: UICollectionViewController {
         guard let id = segue.identifier else { return }
         
         if id == "toDetailSegue" {
-            let nextVC = segue.destination as! AnniversaryDetailVC
+            let nextVC = segue.destination as! AnnivDetailVC
             guard let indexPath = collectionView.indexPathsForSelectedItems?.first else { return }
             switch indexPath.section {
             case 0:
-                nextVC.anniversary = notFinishedAnniversarys[indexPath.row]
+                nextVC.anniv = notFinishedAnnivs[indexPath.row]
             case 1:
-                nextVC.anniversary = finishedAnniversarys[indexPath.row]
+                nextVC.anniv = finishedAnnivs[indexPath.row]
             default : fatalError()
             }
         }
@@ -101,7 +101,7 @@ final class AnniversaryVC: UICollectionViewController {
     /// 他の画面からこの画面へ戻ってくる
     ///
     /// - Parameter segue: Segue
-    @IBAction func returnToAnniversaryVC(segue: UIStoryboardSegue) {}
+    @IBAction func returnToAnnivVC(segue: UIStoryboardSegue) {}
     
     // MARK: - Misc method
     
@@ -124,7 +124,7 @@ final class AnniversaryVC: UICollectionViewController {
     
     /// 記念日データ変更監視用リスナー登録
     private func registerListener() {
-        let filteredCollection = AnniversaryDAO.getQuery(whereField: "isHidden", equalTo: false)
+        let filteredCollection = AnnivDAO.getQuery(whereField: "isHidden", equalTo: false)
         // anniversaryコレクションの変更を監視するリスナー登録
         listenerRegistration = filteredCollection?.addSnapshotListener { snapshot, error in
             guard let snapshot = snapshot else {
@@ -132,8 +132,8 @@ final class AnniversaryVC: UICollectionViewController {
                 return
             }
             print("anniversaryコレクション変更リスナー登録！")
-            self.notFinishedAnniversarys.removeAll()
-            self.finishedAnniversarys.removeAll()
+            self.notFinishedAnnivs.removeAll()
+            self.finishedAnnivs.removeAll()
             // 記念日データが入ったドキュメントの数だけ繰り返す
             for doc in snapshot.documents {
                 // ドキュメントから記念日データを取り出す
@@ -147,18 +147,18 @@ final class AnniversaryVC: UICollectionViewController {
                 data["remainingDays"] = remainingDays
                 // 残日数も含めた記念日データをローカル配列に記憶
                 if remainingDays < 0, !isAnnualy {
-                    self.finishedAnniversarys.append(data)
+                    self.finishedAnnivs.append(data)
                 } else {
-                    self.notFinishedAnniversarys.append(data)
+                    self.notFinishedAnnivs.append(data)
                 }
             }
             // 記念日までの残日数順で並び替える
-            self.notFinishedAnniversarys.sort(by: {($0["remainingDays"] as! Int) < ($1["remainingDays"] as! Int)})
-            self.finishedAnniversarys.sort(by: {($0["remainingDays"] as! Int) < ($1["remainingDays"] as! Int)})
+            self.notFinishedAnnivs.sort(by: {($0["remainingDays"] as! Int) < ($1["remainingDays"] as! Int)})
+            self.finishedAnnivs.sort(by: {($0["remainingDays"] as! Int) < ($1["remainingDays"] as! Int)})
 
-            let yesterdays = self.notFinishedAnniversarys.filter { $0["remainingDays"] as! Int == -1}
-            let otherDays = self.notFinishedAnniversarys.filter { $0["remainingDays"] as! Int != -1}
-            self.notFinishedAnniversarys = otherDays + yesterdays
+            let yesterdays = self.notFinishedAnnivs.filter { $0["remainingDays"] as! Int == -1}
+            let otherDays = self.notFinishedAnnivs.filter { $0["remainingDays"] as! Int != -1}
+            self.notFinishedAnnivs = otherDays + yesterdays
             self.collectionView.reloadData()
         }
     }
@@ -180,7 +180,7 @@ final class AnniversaryVC: UICollectionViewController {
     /// - Returns: セクションの数
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
         // 終了済み記念日があればセクション数を2に増やす
-        let sectionNum = finishedAnniversarys.isEmpty ? 1 : 2
+        let sectionNum = finishedAnnivs.isEmpty ? 1 : 2
         return sectionNum
     }
     
@@ -192,11 +192,11 @@ final class AnniversaryVC: UICollectionViewController {
     /// - Returns: アイテム数
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         // 記念日が一つもないときはガイド用Viewを表示
-        emptySetView.isHidden = notFinishedAnniversarys.count != 0
+        emptySetView.isHidden = notFinishedAnnivs.count != 0
 
         switch section {
-        case 0: return notFinishedAnniversarys.count
-        case 1: return finishedAnniversarys.count
+        case 0: return notFinishedAnnivs.count
+        case 1: return finishedAnnivs.count
             
         default: return 0
         }
@@ -210,23 +210,23 @@ final class AnniversaryVC: UICollectionViewController {
     /// - Returns: CollectionViewCell
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         // Storyboardで設定したカスタムセルIDを指定
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "anniversaryCell", for: indexPath) as! AnniversaryCell
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "anniversaryCell", for: indexPath) as! AnnivCell
         // 記念日データを順に取り出す
         let anniversary: [String : Any]
         switch indexPath.section {
-        case 0: anniversary = self.notFinishedAnniversarys[indexPath.row]
-        case 1: anniversary = self.finishedAnniversarys[indexPath.row]
+        case 0: anniversary = self.notFinishedAnnivs[indexPath.row]
+        case 1: anniversary = self.finishedAnnivs[indexPath.row]
         default: fatalError()
         }
         // 記念日の名前
-        cell.anniversaryNameLabel.text = AnniversaryUtil.getName(from: anniversary)
+        cell.annivNameLabel.text = AnnivUtil.getName(from: anniversary)
         // 記念日の日程
         guard let anniversaryDate = (anniversary["date"] as? Timestamp)?.dateValue() else { return cell }
-        cell.anniversaryDateLabel.text = DateTimeFormat.getMonthDayString(date: anniversaryDate)
+        cell.annivDateLabel.text = DateTimeFormat.getMonthDayString(date: anniversaryDate)
         // 繰り返す記念日か否か
         let isAnnualy = anniversary["isAnnualy"] as! Bool
         // 記念日のアイコン
-        cell.anniversaryIconImage.image = AnniversaryUtil.getIconImage(from: anniversary)
+        cell.annivIconImage.image = AnnivUtil.getIconImage(from: anniversary)
         // 記念日までの残り日数
         let remainingDays = anniversary["remainingDays"] as! Int
         // 過去の記念日かどうか
@@ -239,8 +239,8 @@ final class AnniversaryVC: UICollectionViewController {
         // 近日中の記念日設定
         if 0...30 ~= remainingDays {
             // 文字
-            cell.anniversaryNameLabel.textColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
-            cell.anniversaryDateLabel.textColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+            cell.annivNameLabel.textColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+            cell.annivDateLabel.textColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
             cell.remainingDaysLabel.textColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
             layer = CAGradientLayer()
             layer?.frame = view.bounds
@@ -279,7 +279,7 @@ final class AnniversaryVC: UICollectionViewController {
             fallthrough // 残日数文字列をセットするためにdefaultへ
         default: // 2日以前、31日以降の記念日すべて
             // 記念日までの残り日数文字列
-            cell.remainingDaysLabel.text = AnniversaryUtil.getRemainingDaysString(from: remainingDays)
+            cell.remainingDaysLabel.text = AnnivUtil.getRemainingDaysString(from: remainingDays)
         }
         return cell
     }

--- a/Memoria-iOS/Classes/Views/GiftRecord.storyboard
+++ b/Memoria-iOS/Classes/Views/GiftRecord.storyboard
@@ -217,7 +217,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="Q2c-qO-WPn" kind="show" id="uVZ-xr-yhC"/>
+                                            <segue destination="Q2c-qO-WPn" kind="show" id="uab-Xh-jI5"/>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="dateCell" id="yr0-Og-zsA">
@@ -340,8 +340,8 @@
                         </connections>
                     </tableView>
                     <connections>
-                        <outlet property="anniversaryNameField" destination="Ejd-qn-dk2" id="sWm-zw-3oV"/>
-                        <outlet property="anniversarySelectIcon" destination="XiV-ob-9X2" id="KVh-cw-RHT"/>
+                        <outlet property="annivNameField" destination="Ejd-qn-dk2" id="sWm-zw-3oV"/>
+                        <outlet property="annivSelectIcon" destination="XiV-ob-9X2" id="KVh-cw-RHT"/>
                         <outlet property="dateCell" destination="yr0-Og-zsA" id="qWh-zr-gDz"/>
                         <outlet property="dateField" destination="ghx-vA-H5I" id="1pw-mA-Mk2"/>
                         <outlet property="dateTBDSwitch" destination="OEJ-9p-99Q" id="6c6-Cm-dfx"/>
@@ -380,10 +380,10 @@
             </objects>
             <point key="canvasLocation" x="2402" y="132"/>
         </scene>
-        <!--GiftRecordSelectAnniversary-->
+        <!--GiftRecordSelectAnniv-->
         <scene sceneID="ftl-Kg-EKw">
             <objects>
-                <viewControllerPlaceholder storyboardName="GiftRecordSelectAnniversary" id="Q2c-qO-WPn" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="GiftRecordSelectAnniv" id="Q2c-qO-WPn" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gON-EG-Db1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2402" y="171"/>

--- a/Memoria-iOS/Classes/Views/GiftRecordSelectAnniv.storyboard
+++ b/Memoria-iOS/Classes/Views/GiftRecordSelectAnniv.storyboard
@@ -4,15 +4,16 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Gift Record Select AnniversaryVC-->
+        <!--Gift Record Select AnnivVC-->
         <scene sceneID="F9M-sx-pbt">
             <objects>
-                <viewController id="8aU-jk-lGP" customClass="GiftRecordSelectAnniversaryVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="8aU-jk-lGP" customClass="GiftRecordSelectAnnivVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="PAT-gW-2fb">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -21,7 +22,7 @@
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="resultCell" id="qJu-rs-F0U">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="resultCell" id="qJu-rs-F0U">
                                         <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qJu-rs-F0U" id="I2x-fu-9Vd">

--- a/Memoria-iOS/Classes/Views/GiftRecordSelectAnnivVC.swift
+++ b/Memoria-iOS/Classes/Views/GiftRecordSelectAnnivVC.swift
@@ -1,5 +1,5 @@
 //
-//  GiftRecordSelectAnniversaryVC.swift
+//  GiftRecordSelectAnnivVC.swift
 //  Memoria-iOS
 //
 //  Created by 村松龍之介 on 2018/12/26.
@@ -9,20 +9,20 @@
 import UIKit
 import Firebase
 
-protocol GiftRecordSelectAnniversaryVCDelegate: AnyObject {
+protocol GiftRecordSelectAnnivVCDelegate: AnyObject {
     /// TextFieldの文字列を書き換える
-    func updateAnniversaryName(with text: String?)
+    func updateAnnivName(with text: String?)
 }
 
 /// gift対象記念日を選択するための詳細画面（テーブルセルをタップして遷移してくる）
-class GiftRecordSelectAnniversaryVC: UIViewController {
+class GiftRecordSelectAnnivVC: UIViewController {
 
     // Conform to GiftRecordSelectProtocol
     var displayData = [String]()
     
     @IBOutlet weak var tableView: UITableView!
     // TextFieldの文字列を書き換えるためのDelegateを宣言
-    weak var delegate: GiftRecordSelectAnniversaryVCDelegate?
+    weak var delegate: GiftRecordSelectAnnivVCDelegate?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -32,11 +32,11 @@ class GiftRecordSelectAnniversaryVC: UIViewController {
 }
 
 // MARK: - Confirm GiftRecordSelectProtocol
-extension GiftRecordSelectAnniversaryVC: GiftRecordSelectProtocol {
+extension GiftRecordSelectAnnivVC: GiftRecordSelectProtocol {
     
     func searchDB() {
         // 非表示ではない記念日を検索する
-        AnniversaryDAO.getDocumentsAtDualFilter(first: "isHidden", equalTo: false, secondWhereField: "category", secondEqualTo: "anniversary") { (queryDoc) in
+        AnnivDAO.getDocumentsAtDualFilter(first: "isHidden", equalTo: false, secondWhereField: "category", secondEqualTo: "anniversary") { (queryDoc) in
             for doc in queryDoc {
                 if let title = doc.data()["title"] as? String {
                     self.displayData.append(title)
@@ -53,7 +53,7 @@ extension GiftRecordSelectAnniversaryVC: GiftRecordSelectProtocol {
 }
 
 // MARK: - Table view data source
-extension GiftRecordSelectAnniversaryVC: UITableViewDataSource {
+extension GiftRecordSelectAnnivVC: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return displayData.count
@@ -68,12 +68,12 @@ extension GiftRecordSelectAnniversaryVC: UITableViewDataSource {
 }
 
 // MARK: - Table view delegate
-extension GiftRecordSelectAnniversaryVC: UITableViewDelegate {
+extension GiftRecordSelectAnnivVC: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let text = tableView.cellForRow(at: indexPath)?.textLabel?.text
         print(#function, text ?? "nil")
-        delegate?.updateAnniversaryName(with: text)
+        delegate?.updateAnnivName(with: text)
         
         popVC()
     }

--- a/Memoria-iOS/Classes/Views/GiftRecordSelectPersonVC.swift
+++ b/Memoria-iOS/Classes/Views/GiftRecordSelectPersonVC.swift
@@ -35,7 +35,7 @@ class GiftRecordSelectPersonVC: UIViewController {
 extension GiftRecordSelectPersonVC: GiftRecordSelectProtocol {
     
     func searchDB() {
-        AnniversaryDAO.getFilteredDocuments(whereField: "isHidden", equalTo: false) { (queryDoc) in
+        AnnivDAO.getFilteredDocuments(whereField: "isHidden", equalTo: false) { (queryDoc) in
             for doc in queryDoc {
                 if doc.data()["familyName"] == nil, doc.data()["givenName"] == nil { continue }
                 var fullName = [String]()

--- a/Memoria-iOS/Classes/Views/GiftRecordTableVC.swift
+++ b/Memoria-iOS/Classes/Views/GiftRecordTableVC.swift
@@ -27,7 +27,7 @@ class GiftRecordTableVC: UITableViewController {
     
     enum SegueVC: String {
         case selectPersonVC = "GiftRecordSelectPersonVC"
-        case selectAnniversaryVC = "GiftRecordSelectAnniversaryVC"
+        case selectAnnivVC = "GiftRecordSelectAnnivVC"
     }
     
     
@@ -35,8 +35,8 @@ class GiftRecordTableVC: UITableViewController {
     
     @IBOutlet weak var personNameField: UITextField!
     @IBOutlet weak var personSelectIcon: UIImageView!
-    @IBOutlet weak var anniversarySelectIcon: UIImageView!
-    @IBOutlet weak var anniversaryNameField: UITextField!
+    @IBOutlet weak var annivSelectIcon: UIImageView!
+    @IBOutlet weak var annivNameField: UITextField!
     @IBOutlet weak var dateCell: UITableViewCell!
     @IBOutlet weak var dateField: UITextField!
     @IBOutlet weak var goodsField: UITextField!
@@ -79,8 +79,8 @@ class GiftRecordTableVC: UITableViewController {
         switch segueVC {
         case .selectPersonVC:
             (segue.destination as! GiftRecordSelectPersonVC).delegate = self
-        case .selectAnniversaryVC:
-            (segue.destination as! GiftRecordSelectAnniversaryVC).delegate = self
+        case .selectAnnivVC:
+            (segue.destination as! GiftRecordSelectAnnivVC).delegate = self
         }
     }
     
@@ -112,7 +112,7 @@ class GiftRecordTableVC: UITableViewController {
     
     private func validate() {
         if !(personNameField.text?.isEmpty ?? true),
-            !(anniversaryNameField.text?.isEmpty ?? true),
+            !(annivNameField.text?.isEmpty ?? true),
             !(goodsField.text?.isEmpty ?? true) {
             print("ready!")
             // デリゲートメソッドを実行する
@@ -126,7 +126,7 @@ class GiftRecordTableVC: UITableViewController {
     
     private func setupDesign() {
         personSelectIcon.tintColor = UIColor.init(named: "mainColor")
-        anniversarySelectIcon.tintColor = UIColor.init(named: "mainColor")
+        annivSelectIcon.tintColor = UIColor.init(named: "mainColor")
     }
     
     private func setupDatePicker() {
@@ -152,7 +152,7 @@ class GiftRecordTableVC: UITableViewController {
         toolbar.frame = CGRect(x: 0, y: 0, width: self.view.frame.width, height: 44)
         let next = UIBarButtonItem(title: "next".localized, style: .done, target: self, action: #selector(moveToDateFieldEdit))
         next.tintColor = UIColor.init(named: "mainColor")
-        let previous = UIBarButtonItem(title: "previous".localized, style: .plain, target: self, action: #selector(moveToAnniversaryFieldEdit))
+        let previous = UIBarButtonItem(title: "previous".localized, style: .plain, target: self, action: #selector(moveToAnnivFieldEdit))
         previous.tintColor = UIColor.init(named: "mainColor")
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         
@@ -165,7 +165,7 @@ class GiftRecordTableVC: UITableViewController {
         editingField(dateField, moveToFieldWith: .next)
     }
     
-    @objc private func moveToAnniversaryFieldEdit() {
+    @objc private func moveToAnnivFieldEdit() {
         editingField(dateField, moveToFieldWith: .previous)
     }
 
@@ -265,11 +265,11 @@ extension GiftRecordTableVC: GiftRecordSelectPersonVCDelegate {
     }
 }
 
-// MARK: - GiftRecordSelectAnniversaryVC Delegate
-extension GiftRecordTableVC: GiftRecordSelectAnniversaryVCDelegate {
+// MARK: - GiftRecordSelectAnnivVC Delegate
+extension GiftRecordTableVC: GiftRecordSelectAnnivVCDelegate {
     /// 選択用画面経由で記念日名を更新した時
-    func updateAnniversaryName(with text: String?) {
-        anniversaryNameField.text = text
+    func updateAnnivName(with text: String?) {
+        annivNameField.text = text
         validate()
     }
 }

--- a/Memoria-iOS/Classes/Views/GiftRecordVC.swift
+++ b/Memoria-iOS/Classes/Views/GiftRecordVC.swift
@@ -61,7 +61,7 @@ class GiftRecordVC: UIViewController {
         let gift = GiftDataModel(id: uuid,
                                  isReceived: isReceived,
                                  personName: tableVC.personNameField.text!,
-                                 anniversaryName: tableVC.anniversaryNameField.text!,
+                                 annivName: tableVC.annivNameField.text!,
                                  date: isDateTBD ? nil : tableVC.timestamp ?? Timestamp(),
                                  goods: tableVC.goodsField.text!,
                                  memo: memoView.text,
@@ -101,7 +101,7 @@ class GiftRecordVC: UIViewController {
 
             self.gotOrReceived.selectedSegmentIndex = (gift["isReceived"] as! Bool) ? 0 : 1
             self.tableVC.personNameField.text = gift["personName"] as? String
-            self.tableVC.anniversaryNameField.text = gift["anniversaryName"] as? String
+            self.tableVC.annivNameField.text = gift["anniversaryName"] as? String
             if let timestamp = (gift["date"] as? Timestamp) {
                 self.tableVC.timestamp = timestamp
                 self.tableVC.dateField.text = DateTimeFormat.getYMDString(date: timestamp.dateValue())

--- a/Memoria-iOS/Classes/Views/GiftVC.swift
+++ b/Memoria-iOS/Classes/Views/GiftVC.swift
@@ -134,7 +134,7 @@ class GiftVC: UITableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         print("データ件数: \(gifts.count)件")
         // 一つもないときはガイド用Viewを表示
-//        emptySetView.isHidden = anniversarys.count == 0
+//        emptySetView.isHidden = annivs.count == 0
 //            ? false : true
         
         return gifts.count

--- a/Memoria-iOS/Classes/Views/SettingVC.swift
+++ b/Memoria-iOS/Classes/Views/SettingVC.swift
@@ -51,7 +51,7 @@ class SettingVC: UITableViewController {
                                        message: "deleteContactBirthdayMessage".localized,
                                        destructiveTitle: "delete".localized,
                                        destructiveAction: {
-                                        AnniversaryDAO.deleteQueryAnniversary(whereField: "isFromContact", equalTo: true, on: self)
+                                        AnnivDAO.deleteByQuery(with: "isFromContact", isEqualTo: true, on: self)
         })
     }
     

--- a/Memoria-iOS/Classes/Views/TabBar.storyboard
+++ b/Memoria-iOS/Classes/Views/TabBar.storyboard
@@ -4,6 +4,7 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -29,10 +30,10 @@
             </objects>
             <point key="canvasLocation" x="-430" y="81"/>
         </scene>
-        <!--Anniversary-->
+        <!--Anniv-->
         <scene sceneID="QI6-zi-hba">
             <objects>
-                <viewControllerPlaceholder storyboardName="Anniversary" id="Y4H-rY-N8m" sceneMemberID="viewController">
+                <viewControllerPlaceholder storyboardName="Anniv" id="Y4H-rY-N8m" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Anniversary" image="anniversaryTabBarIcon" badgeValue="1" id="rsL-Rn-4u9"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Mcx-oS-h6a" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Memoria-iOS/Resources/en.lproj/Localizable.strings
+++ b/Memoria-iOS/Resources/en.lproj/Localizable.strings
@@ -112,7 +112,7 @@
 "remainingDaysToday" = "Today!";
 "remainingDaysTomorrow" = "Tomorrow!";
 "remainingDaysYesterday" = "Yesterday";
-// AnniversaryDetail view
+// Anniversary Detail view
 "giftHistory" = "Gift history";
 "hideThisAnniversaryTitle" = "Hide this anniversary";
 "hideThisAnniversaryMessage" = "You can redisplay anniversaries that were hidden in the \"Settings tab\"";


### PR DESCRIPTION
### Issue（課題）リンク [#番号]
#32 

### 概要
**変えたもの**
- ファイル名
- クラス名
- プロパティ名
- メソッド名

**変えていないもの**
- Firestoreのコレクション・ドキュメント名(anniversaryのまま)
- 文字列(String)
- 

### 実装の詳細
`git grep -l anniversary | xargs sed -i '' -e 's/anniversary/anniv/g'`
を試したが、フォルダの再設定等は必要だった。

あとは地道にXcodeのRename機能を使って変更していった

Firestoreのコレクション・ドキュメント名は、ユーザーデータのマイグレーションが必要だったので、今回は見送り。

文字列（ローカリゼーション等）は、文字列の置換が困難なことから今回は断念
（Firestoreのドキュメント名等も文字列なので、一緒に置換してしまう）

### 影響範囲
Anniversaryという名前を使っているところすべて

### テストしたこと
iPhone にて、
1. 記念日を登録、詳細確認、編集できること
2. ギフト登録画面で記念日選択画面が使えること
3. 記念日の非表示、復活、削除ができること

以上の動作を確認しました。