### PR TITLE
「v2.1.0のマイグレーションできないバグ」を修正 fixed #47

### DIFF
--- a/Memoria-iOS.xcodeproj/project.pbxproj
+++ b/Memoria-iOS.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		8D11B3C32195C5CD00C60371 /* AnniversaryDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D11B3C22195C5CC00C60371 /* AnniversaryDetail.storyboard */; };
 		8D11B3C52195CBF300C60371 /* AnniversaryDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D11B3C42195CBF300C60371 /* AnniversaryDetailVC.swift */; };
 		8D11B3C7219719B800C60371 /* TagLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D11B3C6219719B800C60371 /* TagLabel.swift */; };
+		8D17325A22373354005CD22C /* Migration.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D17325922373354005CD22C /* Migration.storyboard */; };
+		8D17325C22373382005CD22C /* MigrationVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D17325B22373382005CD22C /* MigrationVC.swift */; };
 		8D1BFBB22185C6870082C766 /* DateTimeFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1BFBB12185C6870082C766 /* DateTimeFormat.swift */; };
 		8D1C73C32183ED6C00DA5A14 /* AnniversaryVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1C73C22183ED6C00DA5A14 /* AnniversaryVC.swift */; };
 		8D1C73C62183EE0D00DA5A14 /* Anniversary.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D1C73C52183EE0D00DA5A14 /* Anniversary.storyboard */; };
@@ -111,6 +113,8 @@
 		8D11B3C22195C5CC00C60371 /* AnniversaryDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AnniversaryDetail.storyboard; sourceTree = "<group>"; };
 		8D11B3C42195CBF300C60371 /* AnniversaryDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryDetailVC.swift; sourceTree = "<group>"; };
 		8D11B3C6219719B800C60371 /* TagLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagLabel.swift; sourceTree = "<group>"; };
+		8D17325922373354005CD22C /* Migration.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Migration.storyboard; sourceTree = "<group>"; };
+		8D17325B22373382005CD22C /* MigrationVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationVC.swift; sourceTree = "<group>"; };
 		8D1BFBB12185C6870082C766 /* DateTimeFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeFormat.swift; sourceTree = "<group>"; };
 		8D1C73C22183ED6C00DA5A14 /* AnniversaryVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryVC.swift; sourceTree = "<group>"; };
 		8D1C73C52183EE0D00DA5A14 /* Anniversary.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Anniversary.storyboard; path = "Memoria-iOS/Anniversary/Anniversary.storyboard"; sourceTree = SOURCE_ROOT; };
@@ -221,6 +225,8 @@
 			isa = PBXGroup;
 			children = (
 				8D0FB83E2182002700BFCB79 /* AppDelegate.swift */,
+				8D17325922373354005CD22C /* Migration.storyboard */,
+				8D17325B22373382005CD22C /* MigrationVC.swift */,
 				8D77D17C21B28D6200CF673A /* SignIn */,
 				8D77D17521B22AA100CF673A /* SignUp */,
 				8D77D18121B37A3200CF673A /* Passwordless */,
@@ -501,6 +507,7 @@
 				8D11B3B721940BD100C60371 /* Localizable.strings in Resources */,
 				8D8559F821B80AF00033C7AA /* UserAccount.storyboard in Resources */,
 				8DAE856121A2EC6D0049063D /* Welcome.storyboard in Resources */,
+				8D17325A22373354005CD22C /* Migration.storyboard in Resources */,
 				8DA747E921A7C26A007E7F5B /* Setting.storyboard in Resources */,
 				8D1C73C62183EE0D00DA5A14 /* Anniversary.storyboard in Resources */,
 				8D11B3BF21947EAF00C60371 /* InfoPlist.strings in Resources */,
@@ -615,6 +622,7 @@
 				8DD486F421EAD68D0072983A /* Migration.swift in Sources */,
 				8D77D18521B37BED00CF673A /* PasswordlessVC.swift in Sources */,
 				8D4CBB1C21C1511F009BA7C6 /* GiftDAO.swift in Sources */,
+				8D17325C22373382005CD22C /* MigrationVC.swift in Sources */,
 				8D910B5321E2307400D072EA /* InspectableBarButtonItem.swift in Sources */,
 				8DAE856721A2FD520049063D /* WelcomContactVC.swift in Sources */,
 				8DC43FE021D3CC2900B911F2 /* GiftRecordSelectProtocol.swift in Sources */,

--- a/Memoria-iOS/Info.plist
+++ b/Memoria-iOS/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSContactsUsageDescription</key>

--- a/Memoria-iOS/Migration.storyboard
+++ b/Memoria-iOS/Migration.storyboard
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2ak-lY-wwC">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--MigrationVC-->
+        <scene sceneID="e3V-2c-UuC">
+            <objects>
+                <viewController id="2ak-lY-wwC" customClass="MigrationVC" customModule="Memoria_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="wcw-vJ-tJx">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="Aqg-YC-U7o"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Aha-lM-4dy" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Memoria-iOS/MigrationVC.swift
+++ b/Memoria-iOS/MigrationVC.swift
@@ -1,0 +1,23 @@
+//
+//  MigrationVC.swift
+//  Memoria-iOS
+//
+//  Created by 村松龍之介 on 2019/03/12.
+//  Copyright © 2019 nerco studio. All rights reserved.
+//
+
+import UIKit
+
+class MigrationVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+    
+    func startMigration() {
+        Migration.db(on: self) {
+            self.dismiss(animated: true, completion: nil)
+        }
+    }
+}

--- a/Memoria-iOS/TabBarController/TabBarController.swift
+++ b/Memoria-iOS/TabBarController/TabBarController.swift
@@ -12,6 +12,11 @@ import Firebase
 
 class TabBarController: UITabBarController {
     
+    enum Key: String {
+        case isFinishedTutorial
+        case isFinishedMigration210
+    }
+
     var handle: AuthStateDidChangeListenerHandle?
 
     override func viewDidLoad() {
@@ -21,6 +26,9 @@ class TabBarController: UITabBarController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        let userDefaults = UserDefaults.standard
+
         // START: Firebase認証リスナー
         handle = Auth.auth().addStateDidChangeListener { (auth, user) in
             if let user = user {
@@ -30,15 +38,24 @@ class TabBarController: UITabBarController {
                     メールアドレス: \(user.email ?? "nil")
                     画像URL: \(String(describing: user.photoURL))
                     """)
+                // UserDefaultsのデフォルト登録
+                userDefaults.register(defaults: [Key.isFinishedMigration210.rawValue : false])
+                print("Debug log:", "userDefaults.bool(forKey: Key.isFinishedMigration210.rawValue)", "->", userDefaults.bool(forKey: Key.isFinishedMigration210.rawValue))
+                print("Debug log:", "userDefaults.bool(forKey: Key.isFinishedTutorial.rawValue)", "->", userDefaults.bool(forKey: Key.isFinishedTutorial.rawValue))
                 // 初回起動判定
-                if !UserDefaults.standard.bool(forKey: "isFinishedTutorial") {
+                if !userDefaults.bool(forKey: "isFinishedTutorial") {
                     print("初回起動です!")
                     // welcome画面へ遷移
                     let storyboard = UIStoryboard(name: "Welcome", bundle: nil)
                     let nextView = storyboard.instantiateInitialViewController()
                     self.present(nextView!, animated: true, completion: nil)
-                } else {
-                    Migration.db(on: self)
+                } else if !(userDefaults.bool(forKey: Key.isFinishedMigration210.rawValue)) {
+                    print("マイグレーションが必要")
+                    let storyboard = UIStoryboard(name: "Migration", bundle: nil)
+                    let MigrationVC = storyboard.instantiateInitialViewController() as! MigrationVC
+                    self.present(MigrationVC, animated: true) {
+                        MigrationVC.startMigration()
+                    }
                 }
             } else {
                 // 未ログイン状態なら、ログイン画面へ遷移

--- a/Memoria-iOS/Util/Migration.swift
+++ b/Memoria-iOS/Util/Migration.swift
@@ -18,87 +18,83 @@ struct Migration {
     
     static let userDefaults = UserDefaults.standard
     
-    static func db(on rootVC: UIViewController) {
-        
-        userDefaults.register(defaults: [Key.isFinishedMigration210.rawValue : false])
-        
+    static func db(on rootVC: UIViewController, completion: @escaping () -> Void) {
         /* 条件
          1. まだこのマイグレーション判定を通過していない
          2. チュートリアルが終わっている
          */
-        if !userDefaults.bool(forKey: Key.isFinishedMigration210.rawValue),
-            userDefaults.bool(forKey: Key.isFinishedTutorial.rawValue){
-            print("Ver.2.1.0 のマイグレーションを実行")
-            // インジケーター付きアラートダイアログをポップアップ
-            DialogBox.showAlertWithIndicator(on: rootVC, message: "startMigration".localized) {
-                // ☆ isHiddenしかないドキュメントを消すマイグレーションが必要
-                // ① まず、非表示フラグがtrueのデータを検索し、非表示フラグをすべてNullにする
-                AnniversaryDAO.update(searchField: "isHidden", isEqualTo: true, updateField: "isHidden", turns: NSNull()) {
-                    print("Ver.2.1.0 のisHiddenマイグレーションを開始")
-                    // ② 非表示フラグがNullかつ、idがある記念日を検索
-                    AnniversaryDAO.getQuery(whereField: "isHidden", equalTo: NSNull())?.whereField("id", isGreaterThan: "").getDocuments { (query, error) in
-                        if let error = error {
-                            print("Ver.2.1.0 のisHiddenマイグレーション中にエラー発生: \(error)")
-                            DialogBox.dismissAlertWithIndicator(on: rootVC, completion: nil)
-                            return
-                        } else {
-                            print("\(#function)の実行に成功:")
-                        }
-                        // ③ 非表示フラグをすべてfalseにする
-                        query?.documents.forEach { $0.reference.updateData(["isHidden" : false]) }
-                        print("Ver.2.1.0 のisHiddenマイグレーションを終了")
-                        
-                        DialogBox.updateAlert(with: "nextMigration".localized, on: rootVC) {
-                            // ☆ 二つに分けた誕生日を一つにまとめる
-                            // ① 非表示ではない記念日を検索
-                            AnniversaryDAO.getFilteredDocuments(whereField: "isHidden", equalTo: false) { (query) in
-                                print("Ver.2.1.0 の誕生日タイプマイグレーションを開始")
-                                guard query.count > 0 else {
-                                    print("queryが空っぽです")
-                                    print("Ver.2.1.0 の誕生日タイプマイグレーションを終了")
-                                    userDefaults.set(true, forKey: Key.isFinishedMigration210.rawValue)
-                                    DialogBox.dismissAlertWithIndicator(on: rootVC, completion: nil)
-                                    return
-                                }
-                                print("全記念日を調べます")
+        print("Ver.2.1.0 のマイグレーションを実行")
+        // インジケーター付きアラートダイアログをポップアップ
+        DialogBox.showAlertWithIndicator(on: rootVC, message: "startMigration".localized) {
+            // ☆ isHiddenしかないドキュメントを消すマイグレーションが必要
+            // ① まず、非表示フラグがtrueのデータを検索し、非表示フラグをすべてNullにする
+            AnniversaryDAO.update(searchField: "isHidden", isEqualTo: true, updateField: "isHidden", turns: NSNull()) {
+                print("Ver.2.1.0 のisHiddenマイグレーションを開始")
+                // ② 非表示フラグがNullかつ、idがある記念日を検索
+                AnniversaryDAO.getQuery(whereField: "isHidden", equalTo: NSNull())?.whereField("id", isGreaterThan: "").getDocuments { (query, error) in
+                    if let error = error {
+                        print("Ver.2.1.0 のisHiddenマイグレーション中にエラー発生: \(error)")
+                        DialogBox.dismissAlertWithIndicator(on: rootVC, completion: nil)
+                        completion()
+                        return
+                    } else {
+                        print("\(#function)の実行に成功:")
+                    }
+                    // ③ 非表示フラグをすべてfalseにする
+                    query?.documents.forEach { $0.reference.updateData(["isHidden" : false]) }
+                    print("Ver.2.1.0 のisHiddenマイグレーションを終了")
+                    DialogBox.updateAlert(with: "nextMigration".localized, on: rootVC) {
+                        // ☆ 二つに分けた誕生日を一つにまとめる
+                        // ① 非表示ではない記念日を検索
+                        AnniversaryDAO.getFilteredDocuments(whereField: "isHidden", equalTo: false) { (query) in
+                            print("Ver.2.1.0 の誕生日タイプマイグレーションを開始")
+                            guard query.count > 0 else {
+                                print("queryが空っぽです")
+                                print("Ver.2.1.0 の誕生日タイプマイグレーションを終了")
+                                userDefaults.set(true, forKey: Key.isFinishedMigration210.rawValue)
+                                DialogBox.dismissAlertWithIndicator(on: rootVC, completion: nil)
+                                completion()
+                                return
+                            }
+                            print("全記念日を調べます")
+                            for (index, doc) in query.enumerated() {
+                                // 今何個目？
+                                let count = index + 1
+                                let max = query.count
                                 
-                                for (index, doc) in query.enumerated() {
-                                    // 今何個目？
-                                    let count = index + 1
-                                    let max = query.count
+                                print(count, "個目の記念日")
+                                let id = doc.data()["id"] as! String
+                                let category = doc.data()["category"] as! String
+                                
+                                // ② 記念日タイプによって振り分け、各プロパティを更新
+                                switch category {
+                                case "contactBirthday":
+                                    print("\(id) is 'Contact birthday', Migrate to the 'birthday'")
+                                    AnniversaryDAO.update(anniversaryId: id, field: "category", content: "birthday")
+                                    AnniversaryDAO.update(anniversaryId: id, field: "isFromContact", content: true)
                                     
-                                    print(count, "個目の記念日")
-                                    let id = doc.data()["id"] as! String
-                                    let category = doc.data()["category"] as! String
+                                case "manualBirthday":
+                                    print("\(id) is 'Manual birthday', Migrate to the 'birthday'")
+                                    AnniversaryDAO.update(anniversaryId: id, field: "category", content: "birthday")
+                                    AnniversaryDAO.update(anniversaryId: id, field: "isFromContact", content: false)
                                     
-                                    // ② 記念日タイプによって振り分け、各プロパティを更新
-                                    switch category {
-                                    case "contactBirthday":
-                                        print("\(id) is 'Contact birthday', Migrate to the 'birthday'")
-                                        AnniversaryDAO.update(anniversaryId: id, field: "category", content: "birthday")
-                                        AnniversaryDAO.update(anniversaryId: id, field: "isFromContact", content: true)
-                                        
-                                    case "manualBirthday":
-                                        print("\(id) is 'Manual birthday', Migrate to the 'birthday'")
-                                        AnniversaryDAO.update(anniversaryId: id, field: "category", content: "birthday")
-                                        AnniversaryDAO.update(anniversaryId: id, field: "isFromContact", content: false)
-                                        
-                                    case "birthday":
-                                        print("\(id) is 'birthday', Migration is unnecessary")
-                                        
-                                    case "anniversary":
-                                        print("\(id) is 'Anniversary', Add new properties")
-                                        fallthrough
-                                    default:
-                                        print("\(id) is 'Other anniversary', Add new properties")
-                                        AnniversaryDAO.update(anniversaryId: id, field: "isFromContact", content: false)
-                                    }
-                                    // ③ isAnnualyとmemoはすべてのタイプで更新する
-                                    AnniversaryDAO.anniversaryCollection.document(id)
-                                        .updateData(["isAnnualy": true, "memo": ""]) { error in
+                                case "birthday":
+                                    print("\(id) is 'birthday', Migration is unnecessary")
+                                    
+                                case "anniversary":
+                                    print("\(id) is 'Anniversary', Add new properties")
+                                    fallthrough
+                                default:
+                                    print("\(id) is 'Other anniversary', Add new properties")
+                                    AnniversaryDAO.update(anniversaryId: id, field: "isFromContact", content: false)
+                                }
+                                // ③ isAnnualyとmemoはすべてのタイプで更新する
+                                AnniversaryDAO.anniversaryCollection.document(id)
+                                    .updateData(["isAnnualy": true, "memo": ""]) { error in
                                         if let error = error {
                                             DialogBox.dismissAlertWithIndicator(on: rootVC, completion: nil)
                                             print("エラー発生: \(error)")
+                                            completion()
                                             return
                                             
                                         } else {
@@ -113,17 +109,14 @@ struct Migration {
                                             DialogBox.dismissAlertWithIndicator(on: rootVC, completion: nil)
                                             print("Ver.2.1.0 の誕生日タイプマイグレーションを終了")
                                             userDefaults.set(true, forKey: Key.isFinishedMigration210.rawValue)
+                                            completion()
                                         }
-                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-        } else {
-            print("Ver.2.1.0 の誕生日タイプマイグレーションは必要ありません")
-            userDefaults.set(true, forKey: Key.isFinishedMigration210.rawValue)
         }
     }
 }


### PR DESCRIPTION
### Issue（課題）リンク [#番号]
#47

### 概要
アプリをアップデートした人が起動できない現象を修正

### 実装の詳細
記念日一覧画面の表示とマイグレーション処理が同時に行われていたことが原因
新たに画面を用意してそちらでアップデートしてもらうことにした

### テストしたこと
iPhone にて、
1. v2.0.1からv2.1.0へアップデートできること
2. マイグレーションができること

以上の動作を確認しました。