### PR TITLE
fixed #42 「相手の名前」検索条件に「category=birthday」を追加して記念日を除外

### DIFF
--- a/Anniversary.pu
+++ b/Anniversary.pu
@@ -1,19 +1,14 @@
 @startuml
 
-actor Entrant
-
-Entrant -> Ticket : Attend Event Request
-
-activate Ticket
-Ticket -> Member : Create Member Request
-
-activate Member
-Member -> Member : Create Member
-Ticket <-- Member : Create Member Response
-deactivate Member
-
-Ticket -> Ticket : Create Ticket
-Entrant <-- Ticket : Attend Event Response
-deactivate Ticket
+actor User
+User -> AnnivListVC : UIを使ったユーザーアクション
+AnnivListVC -> AnnivListPresenter : Presenterを生成（Viewの参照を渡す）
+AnnivListPresenter -> AnnivListModel : Modelを生成する
+entity Anniv
+AnnivListModel -> Anniv : 記念日データを監視して取得
+Anniv -> AnnivListModel : 記念日データのへ香があれば取得
+AnnivListModel -> AnnivListPresenter : データや結果をPresenterに返す
+AnnivListPresenter -> AnnivListVC : UIの変更を指示する
+AnnivListVC -> User : Viewを更新してユーザーに表示する
 
 @enduml

--- a/Memoria-iOS/Classes/Views/GiftRecordSelectPersonVC.swift
+++ b/Memoria-iOS/Classes/Views/GiftRecordSelectPersonVC.swift
@@ -35,15 +35,17 @@ class GiftRecordSelectPersonVC: UIViewController {
 extension GiftRecordSelectPersonVC: GiftRecordSelectProtocol {
     
     func searchDB() {
-        AnnivDAO.getFilteredDocuments(whereField: "isHidden", equalTo: false) { (queryDoc) in
+        AnnivDAO.getDocumentsAtDualFilter(first: "isHidden", equalTo: false, secondWhereField: "category", secondEqualTo: "birthday") { queryDoc in
             for doc in queryDoc {
-                if doc.data()["familyName"] == nil, doc.data()["givenName"] == nil { continue }
+                let anniv = Anniv(dictionary: doc.data())
                 var fullName = [String]()
-                if let familyName = doc.data()["familyName"] as? String { fullName.append(familyName) }
-                if let givenName = doc.data()["givenName"] as? String { fullName.append(givenName) }
+                if let familyName = anniv?.familyName { fullName.append(familyName) }
+                if let givenName = anniv?.givenName { fullName.append(givenName) }
                 self.displayData.append(String(format: "fullName".localized, arguments: fullName))
             }
-            self.tableView.reloadData()
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
         }
     }
     


### PR DESCRIPTION
### Issue（課題）リンク [#番号]
#42

### 概要
ギフトの登録時に、「相手の名前」を選択できるが、人名を表示するTableViewのセルに空行がある不具合を修正しました。

### 実装の詳細
人名をDBから取得する検索条件の条件設定にcategoryを誕生日に絞る条件が入っていなかったため、誕生日ではない記念日まで取得してしまっていて、それが空行となって表示されていました。

### 影響範囲
ギフトの登録、編集時に、「相手の名前」を選択する画面を表示した際に影響します。

### テストしたこと
iPhone にて、
1. ギフトの新規登録→相手の名前の選択画面へ遷移して空行なく表示されること
2. 既存ギフトの編集→相手の名前の選択画面へ遷移して空行なく表示されること 

以上の動作を確認しました。

### 修正後画面SS
![IMG_A2321A3FF91F-1](https://user-images.githubusercontent.com/8737743/54547279-c225ac80-49e8-11e9-8f27-ab039729cfd2.jpeg)