### PR TITLE
fixed #34 記念日詳細画面でも記念日までの残り日数が「当日」などと表示されるように修正

### DIFF
--- a/Memoria-iOS/Classes/Models/AnnivUtil.swift
+++ b/Memoria-iOS/Classes/Models/AnnivUtil.swift
@@ -42,10 +42,18 @@ struct AnnivUtil {
     /// - Parameter remainingDays: 次回記念日までの日数
     /// - Returns: 後何日か、もしくは何日過ぎたかを文字列で返す
     static func getRemainingDaysString(from remainingDays: Int) -> String {
-        return remainingDays >= 0
-            ? String(format: "remainingDays".localized, remainingDays.description)
-            : String(format: "elapsedDays".localized, (-remainingDays).description)
-        
+        switch remainingDays {
+        case 0: // 今日
+            return "remainingDaysToday".localized
+        case 1:  // 明日
+            return "remainingDaysTomorrow".localized
+        case -1:  // 昨日
+            return "remainingDaysYesterday".localized
+        case ...0:  // 終わった記念日
+            return String(format: "elapsedDays".localized, (-remainingDays).description)
+        default:
+            return String(format: "remainingDays".localized, remainingDays.description)
+        }
     }
     
     /// 記念日のアイコン画像を返す、ない場合はデフォルト画像を返す

--- a/Memoria-iOS/Classes/Views/AnnivCell.swift
+++ b/Memoria-iOS/Classes/Views/AnnivCell.swift
@@ -63,9 +63,6 @@ final class AnnivCell: UICollectionViewCell {
             remainingDaysLabel.font = UIFont.boldSystemFont(ofSize: UIFont.labelFontSize)
         }
         // 記念日の残り日数文字列の設定
-        remainingDaysLabel.text = remainingDays == -1 ? "remainingDaysYesterday".localized
-            : remainingDays == 1 ? "remainingDaysTomorrow".localized
-            : remainingDays == 0 ? "remainingDaysToday".localized
-            : AnnivUtil.getRemainingDaysString(from: remainingDays)
+        remainingDaysLabel.text = AnnivUtil.getRemainingDaysString(from: remainingDays)
     }
 }


### PR DESCRIPTION
### Issue（課題）リンク [#番号]
#34

### 概要
記念日詳細画面でも次の記念日までの日数が記念日一覧画面と同じように表示されるように修正しました。

### 実装の詳細
記念日までの日数文字列を出力するメソッドを共通化して、同じロジックを使用することにしました。

### 影響範囲
記念日一覧画面から記念日を選択して移動する詳細画面の表示

### テストしたこと
iPhone にて、
1. 終わった記念日の日数が「〇〇日前」
2. 当日記念日が「Today!」
3. 明日の記念日が「明日」
4. 昨日の記念日が「昨日」と表示される

以上の動作を確認しました。