### PR TITLE
fixed #45 記念日編集画面で記念日を非表示にした時に、詳細画面ではなくて一覧画面へ一気に戻るように改修

### DIFF
--- a/Memoria-iOS/Classes/Presenters/AnnivDetailPresenter.swift
+++ b/Memoria-iOS/Classes/Presenters/AnnivDetailPresenter.swift
@@ -7,11 +7,13 @@
 //
 
 import Foundation
-
+// MARK: - Presenter Protocols
+/// Viewから指示を受けるためのデリゲート
 protocol AnnivDetailPresenterInput: AnyObject {
     var anniv: Anniv! { get }
     var gifts: [[String: Any]]? { get }
     var numberOfSections: Int { get }
+    func addObserver()
     func addListenerAndUpdateGift()
     func removeGiftListener()
     func numberOfRows(for section: Int) -> Int
@@ -20,13 +22,25 @@ protocol AnnivDetailPresenterInput: AnyObject {
     func heightForRow(at indexPath: IndexPath) -> Float
     func heightForHeader(in section: Int) -> Float?
 }
-
-protocol AnnivDetailPresenterOutput: AnyObject {
+/// Viewに指示を出すためのデリゲート
+@objc protocol AnnivDetailPresenterOutput: AnyObject {
     func update(for gifts: [[String: Any]]?)
+    @objc func popVC()
 }
 
+// MARK: - Notification.Name
+extension Notification.Name {
+    // 文字列の定数化（通知側・受信側で使用）
+    static let popToAnnivListVC = Notification.Name("popToAnnivListVC")
+}
+// MARK: - AnnivDetailPresenter Class
 /// 記念日詳細画面とモデルの仲介役
 final class AnnivDetailPresenter: AnnivDetailPresenterInput {
+    // 記念日一覧画面に戻るためのオブザーバー追加
+    func addObserver() {
+        NotificationCenter.default.addObserver(view, selector: #selector(view.popVC), name: .popToAnnivListVC, object: nil)
+    }
+    
     // MARK: - Enum
     // TableViewのセクション
     enum Section: Int {

--- a/Memoria-iOS/Classes/Views/AnnivDetailVC.swift
+++ b/Memoria-iOS/Classes/Views/AnnivDetailVC.swift
@@ -30,9 +30,9 @@ final class AnnivDetailVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = AnnivUtil.getRemainingDaysString(from: presenter.anniv.remainingDays!)
-        // 記念日一覧画面に戻るためのオブザーバー追加
-        NotificationCenter.default.addObserver(self, selector: #selector(popVC), name: .popToAnnivListVC, object: nil)
+        presenter.addObserver()
     }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         presenter.addListenerAndUpdateGift()
@@ -144,25 +144,14 @@ extension AnnivDetailVC: AnnivDetailPresenterOutput {
         navigationItem.title = AnnivUtil.getRemainingDaysString(from: presenter.anniv.remainingDays!)
         tableView.reloadData()
     }
-    
+    // 一つ前の画面へ戻る
+    @objc func popVC() {
+        navigationController?.popViewController(animated: true)
+    }
     func transitionToAnnivEdit(anniv: Anniv) {
         // TODO: 他Issueにて,Segueから移行する
     }
     func transitionToGiftEdit(anniv: Anniv) {
         // TODO: 他Issueにて,Segueから移行する
-    }
-}
-
-// MARK: - Notification.Name
-extension Notification.Name {
-    // 文字列の定数化（通知側・受信側で使用）
-    static let popToAnnivListVC = Notification.Name("popToAnnivListVC")
-}
-
-// MARK: - Private Methods
-private extension AnnivDetailVC {
-    @objc private func popVC() {
-        // 記念日一覧画面へ戻る
-        navigationController?.popViewController(animated: true)
     }
 }

--- a/Memoria-iOS/Classes/Views/AnnivDetailVC.swift
+++ b/Memoria-iOS/Classes/Views/AnnivDetailVC.swift
@@ -30,8 +30,9 @@ final class AnnivDetailVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = AnnivUtil.getRemainingDaysString(from: presenter.anniv.remainingDays!)
+        // 記念日一覧画面に戻るためのオブザーバー追加
+        NotificationCenter.default.addObserver(self, selector: #selector(popVC), name: .popToAnnivListVC, object: nil)
     }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         presenter.addListenerAndUpdateGift()
@@ -149,5 +150,19 @@ extension AnnivDetailVC: AnnivDetailPresenterOutput {
     }
     func transitionToGiftEdit(anniv: Anniv) {
         // TODO: 他Issueにて,Segueから移行する
+    }
+}
+
+// MARK: - Notification.Name
+extension Notification.Name {
+    // 文字列の定数化（通知側・受信側で使用）
+    static let popToAnnivListVC = Notification.Name("popToAnnivListVC")
+}
+
+// MARK: - Private Methods
+private extension AnnivDetailVC {
+    @objc private func popVC() {
+        // 記念日一覧画面へ戻る
+        navigationController?.popViewController(animated: true)
     }
 }

--- a/Memoria-iOS/Classes/Views/AnnivEditVC.swift
+++ b/Memoria-iOS/Classes/Views/AnnivEditVC.swift
@@ -111,7 +111,10 @@ class AnnivEditVC: UIViewController {
                                 guard let anniversaryData = self.annivModel else { return }
                                 AnnivDAO.update(with: anniversaryData.id, field: "isHidden", content: true)
                                 // 画面を閉じる
-                                self.dismiss(animated: true, completion: nil)
+                                self.dismiss(animated: true) {
+                                    // この画面を閉じた後、すぐに詳細画面一覧画面まで一気に戻る
+                                    NotificationCenter.default.post(name: .popToAnnivListVC, object: nil)
+                                }
         })
     }
     


### PR DESCRIPTION
### Issue（課題）リンク [#番号]
#45

### 概要
今までは、記念日を非表示にした場合、詳細画面を表示していました。
しかし、非表示にした感がなく、一覧画面へ戻った方が良いと感じたため、記念日一覧画面へ一気に戻るようにしました。

### テストしたこと
iPhone にて、
1. 一覧画面 -> 詳細画面 -> 記念日編集画面へ行く
2. 記念日を非表示にする 
3. 詳細画面へ戻った直後に、一覧画面へ戻る

以上の動作を確認しました。

### 修正後動作GIF
![IMB_7e8EkP](https://user-images.githubusercontent.com/8737743/54881151-5207a280-4e90-11e9-9fdf-8c7a24b533a8.GIF)