### PR TITLE
GiftRecordクラスのMVP化

### DIFF
--- a/Memoria-iOS.xcodeproj/project.pbxproj
+++ b/Memoria-iOS.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		8D4CBB2321C51F7E009BA7C6 /* InspectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4CBB2221C51F7E009BA7C6 /* InspectableTextView.swift */; };
 		8D56B2A221A7DAE300B90BED /* SettingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D56B2A121A7DAE300B90BED /* SettingVC.swift */; };
 		8D56B2A421A85A7900B90BED /* OpenOtherApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D56B2A321A85A7900B90BED /* OpenOtherApp.swift */; };
+		8D63BFF922492D4A00AA1B9A /* GiftRecordPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D63BFF822492D4A00AA1B9A /* GiftRecordPresenter.swift */; };
 		8D77D17721B22AD400CF673A /* SignUp.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D77D17621B22AD400CF673A /* SignUp.storyboard */; };
 		8D77D17921B22DC000CF673A /* SignUpVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D77D17821B22DC000CF673A /* SignUpVC.swift */; };
 		8D77D17E21B28DA400CF673A /* SignIn.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D77D17D21B28DA400CF673A /* SignIn.storyboard */; };
@@ -154,6 +155,7 @@
 		8D4CBB2221C51F7E009BA7C6 /* InspectableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectableTextView.swift; sourceTree = "<group>"; };
 		8D56B2A121A7DAE300B90BED /* SettingVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingVC.swift; sourceTree = "<group>"; };
 		8D56B2A321A85A7900B90BED /* OpenOtherApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenOtherApp.swift; sourceTree = "<group>"; };
+		8D63BFF822492D4A00AA1B9A /* GiftRecordPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftRecordPresenter.swift; sourceTree = "<group>"; };
 		8D77D17621B22AD400CF673A /* SignUp.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SignUp.storyboard; sourceTree = "<group>"; };
 		8D77D17821B22DC000CF673A /* SignUpVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpVC.swift; sourceTree = "<group>"; };
 		8D77D17D21B28DA400CF673A /* SignIn.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SignIn.storyboard; sourceTree = "<group>"; };
@@ -373,6 +375,7 @@
 				8D1732572234120E005CD22C /* AnnivListPresenter.swift */,
 				8D2921EE223D0F8D0046917F /* AnnivDetailPresenter.swift */,
 				8D2921FB2243A94E0046917F /* GiftListPresenter.swift */,
+				8D63BFF822492D4A00AA1B9A /* GiftRecordPresenter.swift */,
 			);
 			name = Presenters;
 			path = "Memoria-iOS/Classes/Presenters";
@@ -628,6 +631,7 @@
 				8D1BFBB22185C6870082C766 /* DateTimeFormat.swift in Sources */,
 				8DD474B621CBEB4F00DD5919 /* GiftRecordSelectPersonVC.swift in Sources */,
 				8D00EB1521BB960C00A3A5AE /* UpdatePasswordVC.swift in Sources */,
+				8D63BFF922492D4A00AA1B9A /* GiftRecordPresenter.swift in Sources */,
 				8DF28E7F21A113EF00B62EBA /* NegativeButton.swift in Sources */,
 				8DA747EB21A7C728007E7F5B /* TabBarController.swift in Sources */,
 				8D4CBB1A21C002C3009BA7C6 /* GiftListVC.swift in Sources */,

--- a/Memoria-iOS/Classes/Presenters/GiftListPresenter.swift
+++ b/Memoria-iOS/Classes/Presenters/GiftListPresenter.swift
@@ -23,7 +23,7 @@ protocol GiftListPresenterOutput: AnyObject {
     func update(gifts: [Gift])
     func delete(at: IndexPath)
     func toggleGuidanceView(hasGift: Bool)
-    func transitionToGiftRecord(gift: Gift)
+    func transitionToGiftRecord(gift: Gift?)
 }
 /// ギフトリスト画面とモデルの仲介役
 final class GiftListPresenter: GiftListPresenterInput {

--- a/Memoria-iOS/Classes/Presenters/GiftRecordPresenter.swift
+++ b/Memoria-iOS/Classes/Presenters/GiftRecordPresenter.swift
@@ -1,0 +1,73 @@
+//
+//  GiftRecordPresenter.swift
+//  Memoria-iOS
+//
+//  Created by 村松龍之介 on 2019/03/26.
+//  Copyright © 2019 nerco studio. All rights reserved.
+//
+
+import Foundation
+import Firebase
+/// Viewから指示を受けるためのデリゲート
+protocol GiftRecordPresenterInput: AnyObject {
+    /// 既存のギフト情報を画面に反映させる
+    func setExistGift()
+    /// キャンセルボタンを押した時はダイアログを表示させる
+    /// 新規登録か編集かで文言が変わる
+    func didTapCancelButton(gift: Gift?)
+    /// 画面上で入力された情報を取得し、ギフトを新規登録または編集して画面を閉じる
+    func didTapRecordButton(isReceived: Bool,
+                            isDateTBD: Bool,
+                            personName: String,
+                            annivName: String,
+                            timestamp: Timestamp?,
+                            goods: String,
+                            mwmo: String)
+}
+/// Viewに指示を出すためのデリゲート
+protocol GiftRecordPresenterOutput: AnyObject {
+    /// 使命を終えた自らを閉じる
+    func dismiss(animated: Bool)
+    /// 新規登録か編集かをギフトの有無で判断し、画面レイアウトの設定を行う。
+    func setupLayout(gift: Gift?)
+}
+/// ギフトリスト画面とモデルの仲介役
+final class GiftRecordPresenter: GiftRecordPresenterInput {
+    // View & Model
+    private weak var view: GiftRecordPresenterOutput!
+    /// ギフト（編集の場合は、選択したギフト情報が入る）
+    private(set) var gift: Gift?
+    // PresenterはViewとModelの参照を持つ
+    init(gift: Gift?, view: GiftRecordPresenterOutput) {
+        self.gift = gift
+        self.view = view
+    }
+    
+    func setExistGift() {
+        view.setupLayout(gift: gift)
+    }
+    
+    func didTapCancelButton(gift: Gift?) {
+        let message = gift == nil
+            ? "discardMessageForRecord".localized
+            : "discardMessageForEdit".localized
+        DialogBox.showDestructiveAlert(on: view as! UIViewController, message: message, destructiveTitle: "close".localized) {
+            self.view.dismiss(animated: true)
+        }
+    }
+    func didTapRecordButton(isReceived: Bool, isDateTBD: Bool, personName: String, annivName: String, timestamp: Timestamp?, goods: String, mwmo: String) {
+        let id = gift?.id ?? UUID().uuidString
+        let newGift = Gift(id: id,
+                        isReceived: isReceived,
+                        personName: personName,
+                        annivName: annivName,
+                        date: isDateTBD ? nil : timestamp ?? Timestamp(),
+                        goods: goods,
+                        memo: mwmo,
+                        isHidden: false,
+                        iconImage: nil)
+        // DBに書き込んで画面を閉じる
+        GiftDAO.set(documentPath: id, data: newGift)
+        view.dismiss(animated: true)
+    }
+}

--- a/Memoria-iOS/Classes/Views/AnnivDetailVC.swift
+++ b/Memoria-iOS/Classes/Views/AnnivDetailVC.swift
@@ -49,17 +49,19 @@ final class AnnivDetailVC: UIViewController {
         guard let id = segue.identifier else { return }
         
         if id == "editAnniversarySegue" {
+            // FIXME: Issue#63にてSegueを削除する
             let navC = segue.destination as! UINavigationController
             let nextVC = navC.topViewController as! AnnivEditVC
             nextVC.annivModel = presenter.anniv
         }
         
         if id == "editGiftSegue" {
-            let navC = segue.destination as! UINavigationController
-            let nextVC = navC.topViewController as! GiftRecordVC
-            let indexPath = tableView.indexPathForSelectedRow
-            nextVC.selectedGiftId = presenter.gifts?[indexPath!.row]["id"] as? String
-            print(nextVC.selectedGiftId ?? "selectedGiftId = nil")
+            // FIXME: Issue#62にてSegueを削除する
+//            let navC = segue.destination as! UINavigationController
+//            let nextVC = navC.topViewController as! GiftRecordVC
+//            guard let indexPath = tableView.indexPathForSelectedRow,
+//                let gift = presenter.gifts?[indexPath.row] else { return }
+//            nextVC.gift = Gift(dictionary: gift)
         }
     }
 }
@@ -149,9 +151,9 @@ extension AnnivDetailVC: AnnivDetailPresenterOutput {
         navigationController?.popViewController(animated: true)
     }
     func transitionToAnnivEdit(anniv: Anniv) {
-        // TODO: 他Issueにて,Segueから移行する
+        // TODO: Issue#63にて,Segueから移行する
     }
     func transitionToGiftEdit(anniv: Anniv) {
-        // TODO: 他Issueにて,Segueから移行する
+        // TODO: Issue#62にて,Segueから移行する
     }
 }

--- a/Memoria-iOS/Classes/Views/GiftList.storyboard
+++ b/Memoria-iOS/Classes/Views/GiftList.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zWN-OV-blX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zWN-OV-blX">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -99,7 +99,7 @@
                         <barButtonItem key="rightBarButtonItem" title="add" image="addCircle" id="bKE-ql-25R">
                             <color key="tintColor" name="mainColor"/>
                             <connections>
-                                <segue destination="Plx-vq-7Aw" kind="presentation" id="Rp0-2q-xLP"/>
+                                <action selector="didTapAddButton:" destination="O61-RN-50B" id="u9X-UN-P26"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -114,18 +114,10 @@
             </objects>
             <point key="canvasLocation" x="777" y="11"/>
         </scene>
-        <!--GiftRecord-->
-        <scene sceneID="2Ef-KR-rpR">
-            <objects>
-                <viewControllerPlaceholder storyboardName="GiftRecord" id="Plx-vq-7Aw" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="W3d-ti-TuB" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1419" y="11"/>
-        </scene>
     </scenes>
     <resources>
-        <image name="addCircle" width="48" height="48"/>
-        <image name="roundStars" width="48" height="48"/>
+        <image name="addCircle" width="24" height="24"/>
+        <image name="roundStars" width="24" height="24"/>
         <namedColor name="mainColor">
             <color red="1" green="0.66299998760223389" blue="0.078000001609325409" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Memoria-iOS/Classes/Views/GiftListVC.swift
+++ b/Memoria-iOS/Classes/Views/GiftListVC.swift
@@ -43,6 +43,11 @@ final class GiftListVC: UIViewController {
         super.viewWillDisappear(animated)
         presenter.removeListener()
     }
+    
+    // MARK: - IBAction methods
+    @IBAction func didTapAddButton(_ sender: UIBarButtonItem) {
+        transitionToGiftRecord(gift: nil)
+    }
 }
 
 // MARK: - Table view data source
@@ -100,17 +105,16 @@ extension GiftListVC: GiftListPresenterOutput {
         guidanceView.isHidden = hasGift
     }
     /// ギフトが選択された時に、ギフト編集画面へ遷移する
-    func transitionToGiftRecord(gift: Gift) {
-        let nextVC = UIStoryboard(name: "GiftRecord", bundle: nil)
-            .instantiateInitialViewController()!
-        // TODO: GiftRecordクラスのMVP化の際に有効化する
-        // ModelとPresenterをインスタンス化
-//        let giftRecordModel = GiftRecordModel()
-        // PresenterはViewとModelの参照を持っている
-//        let presenter = GiftRecordPresenter(gift: gift, view: giftRecordVC, model: giftRecordModel)
+    func transitionToGiftRecord(gift: Gift?) {
+        let storyboard = UIStoryboard(name: "GiftRecord", bundle: nil)
+        let giftRecordVC = storyboard.instantiateViewController(withIdentifier: "GiftRecordVC") as! GiftRecordVC
+        let navC = UINavigationController(rootViewController: giftRecordVC)
+        // Presenterをインスタンス化
+        // PresenterはViewの参照を持っている
+        let presenter = GiftRecordPresenter(gift: gift, view: giftRecordVC)
         // ViewにPresenterを注入
-//        giftRecordVC.inject(presenter: presenter)
+        giftRecordVC.inject(presenter: presenter)
         // 編集画面へ遷移
-        navigationController?.present(nextVC, animated: true, completion: nil)
+        present(navC, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
### Issue（課題）リンク [#番号]
#53

### 概要
GiftRecordViewControllerだけだったところを、
GiftRecordPresenterを新規作成してプレゼンテーションロジックを委譲しました。

### 次のPRで修正する範囲
すべての修正を行うと範囲が広くなってしまうので以下の範囲は別PRにて行います。
GiftRecordのTableVCクラス
GiftRecordSelectPersonクラス
GiftRecordSelectAnnivクラス

### 影響範囲
Giftを新規登録、既存ギフトを編集する画面

### テストしたこと
iPhone にて、
1. ギフトの新規登録
2. ギフトの編集

ができることを確認しました。