### PR TITLE
ウォークスルーの最後の画面で終えるボタンを押しても反応がないことがある不具合を解消

### DIFF
--- a/Memoria-iOS/Classes/Views/WelcomContactVC.swift
+++ b/Memoria-iOS/Classes/Views/WelcomContactVC.swift
@@ -23,14 +23,11 @@ class WelcomContactVC: UIViewController, EventTrackable {
             // チュートリアル終了フラグを立てる
             UserDefaults.standard.set(true, forKey: "isFinishedTutorial")
             self.dismiss(animated: true, completion: nil)
-            print("Anniversary画面へ")
         }
     }
     
-    /// Segueが実行されるときの処理
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // チュートリアル終了フラグを立てる
+    @IBAction func didTapLaterButton(_ sender: PositiveButton) {
         UserDefaults.standard.set(true, forKey: "isFinishedTutorial")
-        print("Anniversary画面へ")
+        dismiss(animated: true, completion: nil)
     }
 }

--- a/Memoria-iOS/Classes/Views/WelcomeContact.storyboard
+++ b/Memoria-iOS/Classes/Views/WelcomeContact.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kGm-xq-pr9">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kGm-xq-pr9">
     <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -35,7 +36,7 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="localizedStringKey" value="later"/>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <segue destination="BqF-ae-FP9" kind="unwind" unwindAction="returnToAnniversaryVCWithSegue:" id="neG-Mk-z2j"/>
+                                    <action selector="didTapLaterButton:" destination="kGm-xq-pr9" eventType="touchUpInside" id="ShY-XM-hjQ"/>
                                 </connections>
                             </button>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hLD-Q9-4SU">
@@ -108,12 +109,11 @@
                     <nil key="simulatedBottomBarMetrics"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="v1Z-Uy-DKa" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="BqF-ae-FP9" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="-23.199999999999999" y="99.753694581280797"/>
         </scene>
     </scenes>
     <resources>
-        <image name="WelcomeContact" width="742" height="698"/>
+        <image name="WelcomeContact" width="247.33332824707031" height="232.66667175292969"/>
     </resources>
 </document>

--- a/Memoria-iOS/Resources/Info.plist
+++ b/Memoria-iOS/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1 Dev</string>
+	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>17</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSContactsUsageDescription</key>


### PR DESCRIPTION
### 概要
連絡先を取り込んだ場合は閉じるが、
Laterボタンを押しても画面が閉じずにウォークスルーを終了できない

### 実装の詳細
UnwindSegueで閉じていた箇所が正しく動作していなかった。
戻るべきVCがうまくインスタンス化できていなかったのが原因？
dismissコードでの閉じ方に変更しました。