### PR TITLE
GitHub API (REST)を使用するための構造体を追加

### DIFF
--- a/Memoria-iOS.xcodeproj/project.pbxproj
+++ b/Memoria-iOS.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		8D00EB1521BB960C00A3A5AE /* UpdatePasswordVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D00EB1421BB960C00A3A5AE /* UpdatePasswordVC.swift */; };
 		8D0B3A08226312E300B71A7C /* Cartfile in Resources */ = {isa = PBXBuildFile; fileRef = 8D0B3A07226312E300B71A7C /* Cartfile */; };
 		8D0BE32121A047CB00FE9B40 /* PositiveButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0BE32021A047CB00FE9B40 /* PositiveButton.swift */; };
+		8D0E4A80226BFAC30064B411 /* GitHubIssue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0E4A7F226BFAC30064B411 /* GitHubIssue.swift */; };
+		8D0E4A82226BFFE50064B411 /* GitHubAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0E4A81226BFFE50064B411 /* GitHubAPIClient.swift */; };
 		8D0FB83F2182002700BFCB79 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0FB83E2182002700BFCB79 /* AppDelegate.swift */; };
 		8D0FB8442182002700BFCB79 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D0FB8422182002700BFCB79 /* Main.storyboard */; };
 		8D0FB8462182002800BFCB79 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8D0FB8452182002800BFCB79 /* Assets.xcassets */; };
@@ -117,6 +119,8 @@
 		8D00EB1421BB960C00A3A5AE /* UpdatePasswordVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePasswordVC.swift; sourceTree = "<group>"; };
 		8D0B3A07226312E300B71A7C /* Cartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		8D0BE32021A047CB00FE9B40 /* PositiveButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositiveButton.swift; sourceTree = "<group>"; };
+		8D0E4A7F226BFAC30064B411 /* GitHubIssue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubIssue.swift; sourceTree = "<group>"; };
+		8D0E4A81226BFFE50064B411 /* GitHubAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIClient.swift; sourceTree = "<group>"; };
 		8D0FB83B2182002700BFCB79 /* Memoria-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Memoria-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D0FB83E2182002700BFCB79 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8D0FB8432182002700BFCB79 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -388,6 +392,7 @@
 				8D4CBB1B21C1511F009BA7C6 /* GiftDAO.swift */,
 				8D2921FD2243A9760046917F /* GiftListModel.swift */,
 				8D3DA4B52260416500B59027 /* EventTrackable.swift */,
+				8D0E4A81226BFFE50064B411 /* GitHubAPIClient.swift */,
 			);
 			name = Models;
 			path = "Memoria-iOS/Classes/Models";
@@ -423,6 +428,7 @@
 			children = (
 				8DC43FD921D061C900B911F2 /* Anniv.swift */,
 				8DC43FE321D9F53600B911F2 /* Gift.swift */,
+				8D0E4A7F226BFAC30064B411 /* GitHubIssue.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -687,11 +693,13 @@
 				8DC43FDE21D3C78F00B911F2 /* GiftRecordSelectAnnivVC.swift in Sources */,
 				8D2921F52240F9B80046917F /* AnnivDetailInfoCell.swift in Sources */,
 				8DD486F421EAD68D0072983A /* Migration.swift in Sources */,
+				8D0E4A80226BFAC30064B411 /* GitHubIssue.swift in Sources */,
 				8D2921FC2243A94E0046917F /* GiftListPresenter.swift in Sources */,
 				8D77D18521B37BED00CF673A /* PasswordlessVC.swift in Sources */,
 				8D4CBB1C21C1511F009BA7C6 /* GiftDAO.swift in Sources */,
 				8D17325C22373382005CD22C /* MigrationVC.swift in Sources */,
 				8D910B5321E2307400D072EA /* InspectableBarButtonItem.swift in Sources */,
+				8D0E4A82226BFFE50064B411 /* GitHubAPIClient.swift in Sources */,
 				8DAE856721A2FD520049063D /* WelcomContactVC.swift in Sources */,
 				8DC43FE021D3CC2900B911F2 /* GiftRecordSelectProtocol.swift in Sources */,
 				8D8559FC21B8A3380033C7AA /* UpdateEmailVC.swift in Sources */,

--- a/Memoria-iOS/Classes/Entity/GitHubIssue.swift
+++ b/Memoria-iOS/Classes/Entity/GitHubIssue.swift
@@ -1,0 +1,19 @@
+//
+//  GitHubIssue.swift
+//  Memoria-iOS
+//
+//  Created by 村松龍之介 on 2019/04/21.
+//  Copyright © 2019 nerco studio. All rights reserved.
+//
+
+struct GitHubIssue: Codable {
+    var htmlUrl: String // Snakecaseから変換するのでURLではなくUrlになる
+    var title: String
+    var createdAt: String
+    var updatedAt: String
+    var assignee: Assignee?
+    
+    struct Assignee: Codable {
+        var avatarUrl: String
+    }
+}

--- a/Memoria-iOS/Classes/Models/GitHubAPIClient.swift
+++ b/Memoria-iOS/Classes/Models/GitHubAPIClient.swift
@@ -1,0 +1,54 @@
+//
+//  GitHubAPIClient.swift
+//  Memoria-iOS
+//
+//  Created by 村松龍之介 on 2019/04/21.
+//  Copyright © 2019 nerco studio. All rights reserved.
+//
+
+import Foundation
+
+struct GitHubAPIClient {
+    
+    enum IssueType: String {
+        case bug = "バグ"
+        case enhancement = "機能強化"
+    }
+    
+    private static let repository = "https://api.github.com/repos/Riscait/Memoria-iOS/"
+    
+    /// 指定したラベルのIssueを[GitHub REST API]を使用して取得する
+    static func getIssues(type issueType: IssueType, callback: @escaping ([GitHubIssue]) -> Void) {
+        
+        guard let encodedIssueType = issueType.rawValue.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+            let url = URL(string: "\(repository)issues?labels=\(encodedIssueType)&sort=updated") else { return }
+        
+        var request = URLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 10.0)
+        request.httpMethod = "GET"
+        
+        let session = URLSession.shared
+        let dataTask = session.dataTask(with: request) { data, response, error in
+            if let error = error {
+                Log.warn("エラー発生: \(error)")
+                return
+            }
+            guard let data = data else {
+                Log.warn("データが見つかりません")
+                return
+            }
+            do {
+                let decoder = JSONDecoder()
+                // 用意した構造体に合わせて、JSONのキーのスネークケースをキャメルケースに変換する
+                decoder.keyDecodingStrategy = .convertFromSnakeCase
+                // データの形式をJSONからGitHubIssueに変換する
+                let issues = try decoder.decode([GitHubIssue].self, from: data)
+                Log.info("\(issueType)のIssueを取得: \(issues)")
+                callback(issues)
+                
+            } catch let error {
+                Log.warn("エラー発生: \(error)")
+            }
+        }
+        dataTask.resume()
+    }
+}


### PR DESCRIPTION
### 概要
GitHubのIssue情報を取得するためのクライアントを作成しました。
API v4のGraphQLはハードルが高かったので、情報も多いv3 REST API を使用しました

### 実装の詳細
**GitHubAPIClient**
APIへアクセスするためのstruct
URLSessionでAPIアクセスしデータを取得する

**GitHubIssue**
取得したJSONをデコードするための構造体

### テストしたこと
iPhone にて、
バグ・機能追加など指定したラベルのIssue情報がGitHubIssue型で取得できること
以上の動作を確認しました。

### レビューポイント
今までほとんど使ってこなかったWebAPIの使用です。
URLSessionも経験なかったです。
キャッシュとかタイムアウトとか見よう見まねで実装しました。

GitHubAPIClientという命名も実態に合っているでしょうか？
他の候補: GitHubAPIGateway
もっとクラスを細かく分けた方が良い？